### PR TITLE
feat: add story points field with configurable label

### DIFF
--- a/l10n/bundle.l10n.en.json
+++ b/l10n/bundle.l10n.en.json
@@ -24,6 +24,7 @@
 
   "property.status": "Status",
   "property.priority": "Priority",
+  "property.storyPoints": "Story points",
   "property.assignee": "Assignee",
   "property.dueDate": "Due date",
   "property.labels": "Labels",

--- a/l10n/bundle.l10n.es.json
+++ b/l10n/bundle.l10n.es.json
@@ -24,6 +24,7 @@
 
   "property.status": "Estado",
   "property.priority": "Prioridad",
+  "property.storyPoints": "Puntos de historia",
   "property.assignee": "Asignado",
   "property.dueDate": "Fecha límite",
   "property.labels": "Etiquetas",

--- a/l10n/bundle.l10n.pt.json
+++ b/l10n/bundle.l10n.pt.json
@@ -24,6 +24,7 @@
 
   "property.status": "Estado",
   "property.priority": "Prioridade",
+  "property.storyPoints": "Pontos de história",
   "property.assignee": "Responsável",
   "property.dueDate": "Data limite",
   "property.labels": "Etiquetas",

--- a/package.json
+++ b/package.json
@@ -257,6 +257,11 @@
           "default": false,
           "description": "%config.showFileName.description%"
         },
+        "kanban-markdown.pointsLabel": {
+          "type": "string",
+          "default": "Story points",
+          "description": "%config.pointsLabel.description%"
+        },
         "kanban-markdown.compactMode": {
           "type": "boolean",
           "default": false,

--- a/package.nls.es.json
+++ b/package.nls.es.json
@@ -38,6 +38,7 @@
   "config.showEpic.description": "Mostrar la épica (agrupación principal) en las tarjetas y en los editores.",
   "config.showBuildWithAI.description": "Mostrar el botón 'Construir con IA' en las tarjetas de funciones.",
   "config.showFileName.description": "Mostrar el nombre del archivo markdown de origen en las tarjetas de funciones.",
+  "config.pointsLabel.description": "Etiqueta usada para los valores de puntos en los tooltips del tablero (por ejemplo, Puntos de historia u Horas).",
   "config.compactMode.description": "Usar diseño compacto de tarjetas para mostrar más funciones.",
   "config.addNewCardsToTop.description": "Cuando está activado, las nuevas tarjetas se añaden arriba de la columna en lugar de abajo.",
   "config.markdownEditorMode.description": "Abrir archivos de funciones en el editor de texto nativo de VS Code en lugar del editor de texto enriquecido integrado.",

--- a/package.nls.json
+++ b/package.nls.json
@@ -38,6 +38,7 @@
   "config.showEpic.description": "Show epic (parent grouping) on feature cards and in editors.",
   "config.showBuildWithAI.description": "Show the 'Build with AI' button on feature cards.",
   "config.showFileName.description": "Show the source markdown filename on feature cards.",
+  "config.pointsLabel.description": "Label used for point values in board tooltips (for example, Story points or Hours).",
   "config.compactMode.description": "Use compact card layout to show more features.",
   "config.addNewCardsToTop.description": "When enabled, new cards are added to the top of the column instead of the bottom.",
   "config.markdownEditorMode.description": "Open feature files in VS Code's native text editor instead of the inline rich-text editor.",

--- a/package.nls.pt.json
+++ b/package.nls.pt.json
@@ -38,6 +38,7 @@
   "config.showEpic.description": "Mostrar o épico (agrupamento principal) nos cartões e nos editores.",
   "config.showBuildWithAI.description": "Mostrar o botão 'Construir com IA' nos cartões de funcionalidades.",
   "config.showFileName.description": "Mostrar o nome do ficheiro markdown de origem nos cartões de funcionalidades.",
+  "config.pointsLabel.description": "Etiqueta usada para os valores de pontos nas dicas do quadro (por exemplo, Story points ou Hours).",
   "config.compactMode.description": "Usar disposição compacta de cartões para mostrar mais funcionalidades.",
   "config.addNewCardsToTop.description": "Quando ativado, os novos cartões são adicionados no topo da coluna em vez de no fundo.",
   "config.markdownEditorMode.description": "Abrir ficheiros de funcionalidades no editor de texto nativo do VS Code em vez do editor de texto rico integrado.",

--- a/src/extension/FeatureHeaderProvider.ts
+++ b/src/extension/FeatureHeaderProvider.ts
@@ -4,6 +4,13 @@ import * as path from 'path'
 import type { FeatureFrontmatter, EditorExtensionMessage, EditorWebviewMessage } from '../shared/editorTypes'
 import type { FeatureStatus, Priority, AIAgent } from '../shared/types'
 
+function parseStoryPoints(rawValue: string): number | null {
+  if (!rawValue) return null
+  if (!/^\d+$/.test(rawValue)) return null
+  const parsed = Number.parseInt(rawValue, 10)
+  return Number.isSafeInteger(parsed) ? parsed : null
+}
+
 /**
  * Provides a webview panel that shows feature metadata (frontmatter) as a header.
  * The actual markdown editing is done by VSCode's native text editor.
@@ -279,6 +286,7 @@ export class FeatureHeaderProvider implements vscode.WebviewViewProvider {
       id: getValue('id') || 'unknown',
       status: (getValue('status') as FeatureStatus) || 'backlog',
       priority: (getValue('priority') as Priority) || 'medium',
+      storyPoints: parseStoryPoints(getValue('storyPoints')),
       assignee: getValue('assignee') || null,
       epic: getValue('epic') || null,
       dueDate: getValue('dueDate') || null,
@@ -298,6 +306,7 @@ export class FeatureHeaderProvider implements vscode.WebviewViewProvider {
       id: 'unknown',
       status: 'backlog',
       priority: 'medium',
+      storyPoints: null,
       assignee: null,
       epic: null,
       dueDate: null,
@@ -321,6 +330,7 @@ export class FeatureHeaderProvider implements vscode.WebviewViewProvider {
       `status: "${updatedFrontmatter.status}"`,
       `priority: "${updatedFrontmatter.priority}"`,
       `assignee: ${updatedFrontmatter.assignee ? `"${updatedFrontmatter.assignee}"` : 'null'}`,
+      `storyPoints: ${updatedFrontmatter.storyPoints === null ? 'null' : updatedFrontmatter.storyPoints}`,
       `epic: ${updatedFrontmatter.epic ? `"${updatedFrontmatter.epic}"` : 'null'}`,
       `dueDate: ${updatedFrontmatter.dueDate ? `"${updatedFrontmatter.dueDate}"` : 'null'}`,
       `created: "${updatedFrontmatter.created}"`,

--- a/src/extension/KanbanPanel.ts
+++ b/src/extension/KanbanPanel.ts
@@ -17,6 +17,7 @@ function normalizeEpic(value: string | null | undefined): string | null {
 interface CreateFeatureData {
   status: FeatureStatus
   priority: Priority
+  storyPoints: number | null
   content: string
   assignee: string | null
   epic: string | null
@@ -577,6 +578,7 @@ export class KanbanPanel {
       id: uniqueFilename,
       status: data.status,
       priority: data.priority,
+      storyPoints: data.storyPoints,
       assignee: data.assignee,
       epic: normalizeEpic(data.epic),
       dueDate: data.dueDate,
@@ -836,6 +838,7 @@ export class KanbanPanel {
       id: feature.id,
       status: feature.status,
       priority: feature.priority,
+      storyPoints: feature.storyPoints,
       assignee: feature.assignee,
       epic: feature.epic,
       dueDate: feature.dueDate,
@@ -871,6 +874,7 @@ export class KanbanPanel {
     feature.content = content
     feature.status = frontmatter.status
     feature.priority = frontmatter.priority
+    feature.storyPoints = frontmatter.storyPoints
     feature.assignee = frontmatter.assignee
     feature.epic = normalizeEpic(frontmatter.epic)
     feature.dueDate = frontmatter.dueDate
@@ -1160,6 +1164,7 @@ export class KanbanPanel {
       showEpic: config.get<boolean>('showEpic', true),
       showBuildWithAI: config.get<boolean>('showBuildWithAI', true) && !vscode.workspace.getConfiguration('chat').get<boolean>('disableAIFeatures', false),
       showFileName: config.get<boolean>('showFileName', false),
+      pointsLabel: config.get<string>('pointsLabel', 'Story points'),
       compactMode: config.get<boolean>('compactMode', false),
       markdownEditorMode: config.get<boolean>('markdownEditorMode', false),
       hideScrollbar: config.get<boolean>('hideScrollbar', false),

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -83,6 +83,7 @@ async function createFeatureFromPrompts(): Promise<void> {
     id: filename,
     status,
     priority,
+    storyPoints: null,
     assignee: null,
     epic: null,
     dueDate: null,

--- a/src/shared/featureFrontmatter.ts
+++ b/src/shared/featureFrontmatter.ts
@@ -1,6 +1,13 @@
 import * as path from 'path'
 import type { Feature, FeatureStatus, Priority } from './types'
 
+function parseStoryPoints(rawValue: string): number | null {
+  if (!rawValue) return null
+  if (!/^\d+$/.test(rawValue)) return null
+  const parsed = Number.parseInt(rawValue, 10)
+  return Number.isSafeInteger(parsed) ? parsed : null
+}
+
 export function parseFeatureFile(content: string, filePath: string): Feature | null {
   content = content.replace(/\r\n/g, '\n')
   const frontmatterMatch = content.match(/^---\n([\s\S]*?)\n---\n?([\s\S]*)$/)
@@ -26,6 +33,7 @@ export function parseFeatureFile(content: string, filePath: string): Feature | n
     id: getValue('id') || path.basename(filePath, '.md'),
     status: (getValue('status') as FeatureStatus) || 'backlog',
     priority: (getValue('priority') as Priority) || 'medium',
+    storyPoints: parseStoryPoints(getValue('storyPoints')),
     assignee: getValue('assignee') || null,
     epic: getValue('epic') || null,
     dueDate: getValue('dueDate') || null,
@@ -46,6 +54,7 @@ export function serializeFeature(feature: Feature): string {
     `status: "${feature.status}"`,
     `priority: "${feature.priority}"`,
     `assignee: ${feature.assignee ? `"${feature.assignee}"` : 'null'}`,
+    `storyPoints: ${feature.storyPoints === null ? 'null' : feature.storyPoints}`,
     `epic: ${feature.epic ? `"${feature.epic}"` : 'null'}`,
     `dueDate: ${feature.dueDate ? `"${feature.dueDate}"` : 'null'}`,
     `created: "${feature.created}"`,

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -11,6 +11,7 @@ export interface Feature {
   id: string
   status: FeatureStatus
   priority: Priority
+  storyPoints: number | null
   assignee: string | null
   epic: string | null
   dueDate: string | null
@@ -82,6 +83,7 @@ export interface CardDisplaySettings {
   showEpic: boolean
   showBuildWithAI: boolean
   showFileName: boolean
+  pointsLabel: string
   compactMode: boolean
   markdownEditorMode: boolean
   hideScrollbar: boolean
@@ -111,6 +113,7 @@ export interface FeatureFrontmatter {
   id: string
   status: FeatureStatus
   priority: Priority
+  storyPoints: number | null
   assignee: string | null
   epic: string | null
   dueDate: string | null
@@ -123,7 +126,7 @@ export interface FeatureFrontmatter {
 
 export type WebviewMessage =
   | { type: 'ready' }
-  | { type: 'createFeature'; data: { status: FeatureStatus; priority: Priority; content: string; assignee: string | null; epic: string | null; dueDate: string | null; labels: string[] } }
+  | { type: 'createFeature'; data: { status: FeatureStatus; priority: Priority; storyPoints: number | null; content: string; assignee: string | null; epic: string | null; dueDate: string | null; labels: string[] } }
   | { type: 'moveFeature'; featureId: string; newStatus: string; newOrder: number }
   | { type: 'deleteFeature'; featureId: string }
   | { type: 'updateFeature'; featureId: string; updates: Partial<Feature> }

--- a/src/webview/App.tsx
+++ b/src/webview/App.tsx
@@ -296,6 +296,7 @@ function App(): React.JSX.Element {
   const handleCreateFeature = (data: {
     status: FeatureStatus
     priority: Priority
+    storyPoints: number | null
     content: string
     assignee: string | null
     epic: string | null

--- a/src/webview/components/CreateFeatureDialog.tsx
+++ b/src/webview/components/CreateFeatureDialog.tsx
@@ -5,7 +5,7 @@ import { useEditor, EditorContent } from '@tiptap/react'
 import StarterKit from '@tiptap/starter-kit'
 import Placeholder from '@tiptap/extension-placeholder'
 import { Markdown } from 'tiptap-markdown'
-import { X, ChevronDown, User, Tag, Check, CircleDot, Signal, Calendar, Layers } from 'lucide-react'
+import { X, ChevronDown, User, Tag, Check, CircleDot, Signal, Calendar, Layers, Hash } from 'lucide-react'
 import type { FeatureStatus, Priority } from '../../shared/types'
 import { useStore } from '../store'
 import { cn } from '../lib/utils'
@@ -23,16 +23,16 @@ function getMarkdown(editor: { storage: unknown }): string {
 interface CreateFeatureDialogProps {
   isOpen: boolean
   onClose: () => void
-  onCreate: (data: {
-    status: FeatureStatus
-    priority: Priority
-    content: string
-    assignee: string | null
-    epic: string | null
-    dueDate: string | null
-    labels: string[]
-  }) => void
+  onCreate: (data: { status: FeatureStatus; priority: Priority; storyPoints: number | null; content: string; assignee: string | null; epic: string | null; dueDate: string | null; labels: string[] }) => void
   initialStatus?: FeatureStatus
+}
+
+function parseStoryPointsInput(value: string): number | null {
+  const trimmed = value.trim()
+  if (trimmed === '') return null
+  if (!/^\d+$/.test(trimmed)) return null
+  const parsed = Number.parseInt(trimmed, 10)
+  return Number.isSafeInteger(parsed) ? parsed : null
 }
 
 function getPriorityConfig(): { value: Priority; label: string; dot: string }[] {
@@ -306,12 +306,14 @@ function CreateFeatureDialogContent({
   initialStatus
 }: CreateFeatureDialogProps) {
   const { cardSettings } = useStore()
+  const pointsLabel = cardSettings.pointsLabel?.trim() || t('property.storyPoints')
   const priorityConfig = getPriorityConfig()
   const statusConfig = getStatusConfig()
   const [title, setTitle] = useState('')
   const [status, setStatus] = useState<FeatureStatus>(initialStatus ?? cardSettings.defaultStatus)
   const [priority, setPriority] = useState<Priority>(cardSettings.defaultPriority)
   const [assignee, setAssignee] = useState('')
+  const [storyPointsInput, setStoryPointsInput] = useState('')
   const [dueDate, setDueDate] = useState('')
   const [labels, setLabels] = useState<string[]>([])
   const [epic, setEpic] = useState('')
@@ -341,10 +343,13 @@ function CreateFeatureDialogContent({
     const description = descriptionEditor ? getMarkdown(descriptionEditor).trim() : ''
     const heading = title.trim()
     if (!heading && !description) return
-    const content = heading ? `# ${heading}${description ? '\n\n' + description : ''}` : description
+    const content = heading
+      ? `# ${heading}${description ? '\n\n' + description : ''}`
+      : description
     onCreate({
       status,
       priority,
+      storyPoints: parseStoryPointsInput(storyPointsInput),
       content,
       assignee: assignee.trim() || null,
       epic: epic.trim() || null,
@@ -444,6 +449,27 @@ function CreateFeatureDialogContent({
               <AssigneeInput value={assignee} onChange={setAssignee} />
             </PropertyRow>
           )}
+          {cardSettings.showEpic && (
+            <PropertyRow label={t('property.epic')} icon={<Layers size={13} />}>
+              <EpicInput value={epic} onChange={setEpic} />
+            </PropertyRow>
+          )}
+          <PropertyRow label={pointsLabel} icon={<Hash size={13} />}>
+            <input
+              type="text"
+              inputMode="numeric"
+              pattern="[0-9]*"
+              value={storyPointsInput}
+              onChange={(e) => {
+                const next = e.target.value
+                if (next !== '' && !/^\d+$/.test(next)) return
+                setStoryPointsInput(next)
+              }}
+              placeholder="-"
+              className="bg-transparent border-none outline-none text-xs w-full"
+              style={{ color: storyPointsInput ? 'var(--vscode-foreground)' : 'var(--vscode-descriptionForeground)' }}
+            />
+          </PropertyRow>
           {cardSettings.showEpic && (
             <PropertyRow label={t('property.epic')} icon={<Layers size={13} />}>
               <EpicInput value={epic} onChange={setEpic} />

--- a/src/webview/components/FeatureCard.tsx
+++ b/src/webview/components/FeatureCard.tsx
@@ -1,4 +1,4 @@
-import { Calendar, Check, FileText, Layers } from 'lucide-react'
+import { Calendar, FileText, Layers } from 'lucide-react'
 import { getTitleFromContent } from '../../shared/types'
 import type { Feature, Priority } from '../../shared/types'
 import { epicThemeFromName } from '../../shared/epicColor'
@@ -66,29 +66,8 @@ export function FeatureCard({ feature, onClick, isDragging }: FeatureCardProps) 
 
   const dueInfo = feature.status === 'done' ? null : formatDueDate(feature.dueDate)
 
-  const formatCompletedAt = (dateStr: string | null) => {
-    if (!dateStr) return null
-    const completed = new Date(dateStr)
-    const now = new Date()
-    const diffMs = now.getTime() - completed.getTime()
-    const diffMins = Math.floor(diffMs / (1000 * 60))
-    const diffHours = Math.floor(diffMs / (1000 * 60 * 60))
-    const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24))
-
-    if (diffMins < 1) return t('card.justNow')
-    if (diffMins < 60) return t('card.minutesAgo', { count: diffMins })
-    if (diffHours < 24) return t('card.hoursAgo', { count: diffHours })
-    if (diffDays === 1) return t('card.oneDayAgo')
-    if (diffDays < 30) return t('card.daysAgo', { count: diffDays })
-    if (diffDays < 365) return t('card.monthsAgo', { count: Math.floor(diffDays / 30) })
-    return t('card.yearsAgo', { count: Math.floor(diffDays / 365) })
-  }
-
-  const completedText = feature.status === 'done' ? formatCompletedAt(feature.completedAt) : null
-
   const epicTrimmed = feature.epic?.trim()
   const epicTheme = epicTrimmed ? epicThemeFromName(epicTrimmed, isDarkMode) : null
-
   return (
     <div
       onClick={onClick}
@@ -164,14 +143,14 @@ export function FeatureCard({ feature, onClick, isDragging }: FeatureCardProps) 
       </div>
 
       {/* Footer */}
-      <div className="flex items-center justify-between text-xs mt-auto">
-        <div className="flex items-center gap-1">
+      <div className="flex items-center justify-between gap-2 text-xs mt-auto">
+        <div className="flex items-center gap-1 flex-1 min-w-0">
           {cardSettings.showAssignee && feature.assignee && feature.assignee !== 'null' && (
-            <div className="flex items-center gap-1.5 text-zinc-500 dark:text-zinc-400">
+            <div className="flex items-center gap-1.5 text-zinc-500 dark:text-zinc-400 min-w-0">
               <span className="shrink-0 w-4 h-4 rounded-full flex items-center justify-center text-[8px] font-bold bg-zinc-200 dark:bg-zinc-600 text-zinc-700 dark:text-zinc-300">
                 {feature.assignee.split(/\s+/).map((w: string) => w[0]).join('').toUpperCase().slice(0, 2)}
               </span>
-              <span>{feature.assignee}</span>
+              <span className="truncate">{feature.assignee}</span>
             </div>
           )}
         </div>
@@ -181,10 +160,9 @@ export function FeatureCard({ feature, onClick, isDragging }: FeatureCardProps) 
             <span>{dueInfo.text}</span>
           </div>
         )}
-        {completedText && (
-          <div className="flex items-center gap-1" style={{ color: 'var(--vscode-descriptionForeground)' }}>
-            <Check size={12} />
-            <span>{completedText}</span>
+        {feature.storyPoints !== null && (
+          <div className="text-zinc-500 dark:text-zinc-400 text-right truncate max-w-[40%]">
+            {feature.storyPoints}
           </div>
         )}
       </div>

--- a/src/webview/components/FeatureEditor.tsx
+++ b/src/webview/components/FeatureEditor.tsx
@@ -16,7 +16,8 @@ import {
   Calendar,
   Trash2,
   FileText,
-  Layers
+  Layers,
+  Hash
 } from 'lucide-react'
 import type {
   FeatureFrontmatter,
@@ -72,6 +73,14 @@ function getStatusLabels(): Record<FeatureStatus, string> {
 
 const priorities: Priority[] = ['critical', 'high', 'medium', 'low']
 const statuses: FeatureStatus[] = ['backlog', 'todo', 'in-progress', 'review', 'done']
+
+function parseStoryPointsInput(value: string): number | null {
+  const trimmed = value.trim()
+  if (trimmed === '') return null
+  if (!/^\d+$/.test(trimmed)) return null
+  const parsed = Number.parseInt(trimmed, 10)
+  return Number.isSafeInteger(parsed) ? parsed : null
+}
 
 const priorityDots: Record<Priority, string> = {
   critical: 'bg-red-500',
@@ -535,6 +544,7 @@ export function FeatureEditor({
   onStartWithAI
 }: FeatureEditorProps) {
   const { cardSettings } = useStore()
+  const pointsLabel = cardSettings.pointsLabel?.trim() || t('property.storyPoints')
   const [currentFrontmatter, setCurrentFrontmatter] = useState(frontmatter)
   const [confirmingDelete, setConfirmingDelete] = useState(false)
   const priorityLabels = getPriorityLabels()
@@ -759,6 +769,29 @@ export function FeatureEditor({
             />
           </PropertyRow>
         )}
+        <PropertyRow label={pointsLabel} icon={<Hash size={13} />}>
+          <input
+            type="text"
+            inputMode="numeric"
+            pattern="[0-9]*"
+            value={
+              currentFrontmatter.storyPoints === null ? '' : String(currentFrontmatter.storyPoints)
+            }
+            onChange={(e) => {
+              const next = e.target.value
+              if (next !== '' && !/^\d+$/.test(next)) return
+              handleFrontmatterUpdate({ storyPoints: parseStoryPointsInput(next) })
+            }}
+            placeholder="-"
+            className="bg-transparent border-none outline-none text-xs w-full"
+            style={{
+              color:
+                currentFrontmatter.storyPoints === null
+                  ? 'var(--vscode-descriptionForeground)'
+                  : 'var(--vscode-foreground)'
+            }}
+          />
+        </PropertyRow>
         {cardSettings.showEpic && (
           <PropertyRow label={t('property.epic')} icon={<Layers size={13} />}>
             <EpicInput

--- a/src/webview/components/KanbanColumn.tsx
+++ b/src/webview/components/KanbanColumn.tsx
@@ -3,6 +3,7 @@ import { useState, useRef, useEffect } from 'react'
 import { FeatureCard } from './FeatureCard'
 import type { Feature, KanbanColumn as KanbanColumnType } from '../../shared/types'
 import type { LayoutMode } from '../store'
+import { useStore } from '../store'
 import type { DropTarget } from './KanbanBoard'
 import { t } from '../lib/i18n'
 
@@ -45,6 +46,32 @@ export function KanbanColumn({
 }: KanbanColumnProps) {
   const isVertical = layout === 'vertical'
   const isDropTarget = dropTarget && dropTarget.columnId === column.id
+  const pointsLabel = useStore((s) => s.cardSettings.pointsLabel?.trim() || 'Story points')
+  const storyPointsTotal = features.reduce((sum, feature) => sum + (feature.storyPoints ?? 0), 0)
+  const groupedByAssignee = features.reduce<Map<string, Feature[]>>((acc, feature) => {
+    const key = feature.assignee?.trim() || t('toolbar.unassigned')
+    const existing = acc.get(key) ?? []
+    existing.push(feature)
+    acc.set(key, existing)
+    return acc
+  }, new Map())
+  const assigneeBuckets = Array.from(groupedByAssignee.entries()).map(([assignee, groupedFeatures]) => ({
+    assignee,
+    cards: groupedFeatures.length,
+    points: groupedFeatures.reduce((sum, feature) => sum + (feature.storyPoints ?? 0), 0)
+  }))
+  const cardsBreakdown = assigneeBuckets
+    .map((entry) => ({
+      assignee: entry.assignee,
+      value: entry.cards
+    }))
+    .sort((a, b) => (b.value - a.value) || a.assignee.localeCompare(b.assignee))
+  const pointsBreakdown = assigneeBuckets
+    .map((entry) => ({
+      assignee: entry.assignee,
+      value: entry.points
+    }))
+    .sort((a, b) => (b.value - a.value) || a.assignee.localeCompare(b.assignee))
   const [menuOpen, setMenuOpen] = useState(false)
   const [submenuOpen, setSubmenuOpen] = useState(false)
   const menuRef = useRef<HTMLDivElement>(null)
@@ -75,9 +102,34 @@ export function KanbanColumn({
         <div className="flex items-center gap-2">
           <div className="w-2 h-2 rounded-full" style={{ backgroundColor: column.color }} />
           <h3 className="text-sm font-medium text-zinc-900 dark:text-zinc-100">{column.name}</h3>
-          <span className="text-xs text-zinc-500 dark:text-zinc-400 bg-zinc-200 dark:bg-zinc-700 px-1.5 py-0.5 rounded-full">
-            {features.length}
-          </span>
+          <div className="relative group">
+            <span className="text-xs text-zinc-500 dark:text-zinc-400 bg-zinc-200 dark:bg-zinc-700 px-1.5 py-0.5 rounded-full">
+              {features.length}
+            </span>
+            <div className="absolute top-full left-0 mt-1 z-30 min-w-[180px] max-w-[260px] rounded-md border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-800 shadow-lg p-2 opacity-0 pointer-events-none group-hover:opacity-100 group-hover:pointer-events-auto transition-opacity">
+              <div className="text-xs font-medium text-zinc-900 dark:text-zinc-100 mb-1">Cards: {features.length}</div>
+              {cardsBreakdown.map((entry) => (
+                <div key={`cards-${entry.assignee}`} className="text-xs text-zinc-600 dark:text-zinc-300 flex items-center justify-between gap-2">
+                  <span className="truncate">{entry.assignee}</span>
+                  <span>{entry.value}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+          <div className="relative group">
+            <span className="text-xs text-zinc-500 dark:text-zinc-400 bg-zinc-200 dark:bg-zinc-700 px-1.5 py-0.5 rounded-full">
+              {storyPointsTotal}
+            </span>
+            <div className="absolute top-full left-0 mt-1 z-30 min-w-[180px] max-w-[260px] rounded-md border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-800 shadow-lg p-2 opacity-0 pointer-events-none group-hover:opacity-100 group-hover:pointer-events-auto transition-opacity">
+              <div className="text-xs font-medium text-zinc-900 dark:text-zinc-100 mb-1">{pointsLabel}: {storyPointsTotal}</div>
+              {pointsBreakdown.map((entry) => (
+                <div key={`points-${entry.assignee}`} className="text-xs text-zinc-600 dark:text-zinc-300 flex items-center justify-between gap-2">
+                  <span className="truncate">{entry.assignee}</span>
+                  <span>{entry.value}</span>
+                </div>
+              ))}
+            </div>
+          </div>
         </div>
         <div className="flex items-center gap-0.5">
           <button

--- a/src/webview/store/index.ts
+++ b/src/webview/store/index.ts
@@ -109,6 +109,7 @@ export const useStore = create<KanbanState>((set, get) => ({
     showEpic: true,
     showBuildWithAI: true,
     showFileName: false,
+    pointsLabel: 'Story points',
     compactMode: false,
     markdownEditorMode: false,
     hideScrollbar: false,

--- a/tests/integration/suite/extension.test.ts
+++ b/tests/integration/suite/extension.test.ts
@@ -65,6 +65,7 @@ function makeFeature(overrides: Partial<Feature> = {}): Feature {
     id: 'test-id-001',
     status: 'todo',
     priority: 'high',
+    storyPoints: 5,
     assignee: 'alice',
     epic: null,
     dueDate: '2026-06-01',
@@ -254,6 +255,7 @@ suite('Integration: frontmatter round-trip with vscode.workspace.fs', () => {
     assert.strictEqual(parsed!.id, feature.id)
     assert.strictEqual(parsed!.status, feature.status)
     assert.strictEqual(parsed!.priority, feature.priority)
+    assert.strictEqual(parsed!.storyPoints, feature.storyPoints)
     assert.strictEqual(parsed!.assignee, feature.assignee)
     assert.strictEqual(parsed!.dueDate, feature.dueDate)
     assert.strictEqual(parsed!.order, feature.order)
@@ -264,6 +266,7 @@ suite('Integration: frontmatter round-trip with vscode.workspace.fs', () => {
   test('null optional fields survive round-trip', async () => {
     const feature = makeFeature({
       priority: 'medium',
+      storyPoints: null,
       assignee: null,
       dueDate: null,
       completedAt: null,
@@ -276,6 +279,7 @@ suite('Integration: frontmatter round-trip with vscode.workspace.fs', () => {
     const parsed = parseFeatureFile(content, filePath)
 
     assert.ok(parsed !== null)
+    assert.strictEqual(parsed!.storyPoints, null)
     assert.strictEqual(parsed!.assignee, null)
     assert.strictEqual(parsed!.dueDate, null)
     assert.strictEqual(parsed!.completedAt, null)

--- a/tests/shared/featureFrontmatter.test.ts
+++ b/tests/shared/featureFrontmatter.test.ts
@@ -13,6 +13,7 @@ function makeFeature(overrides: Partial<Feature> = {}): Feature {
     id: 'abc-123',
     status: 'in-progress',
     priority: 'high',
+    storyPoints: 3,
     assignee: 'foo',
     epic: null,
     dueDate: '2026-03-01',
@@ -32,6 +33,7 @@ function makeFrontmatter(overrides: Record<string, string> = {}): string {
     id: '"abc-123"',
     status: '"in-progress"',
     priority: '"high"',
+    storyPoints: '3',
     assignee: '"foo"',
     epic: 'null',
     dueDate: '"2026-03-01"',
@@ -59,6 +61,7 @@ describe('parseFeatureFile', () => {
     expect(feature!.id).toBe('abc-123')
     expect(feature!.status).toBe('in-progress')
     expect(feature!.priority).toBe('high')
+    expect(feature!.storyPoints).toBe(3)
     expect(feature!.assignee).toBe('foo')
     expect(feature!.epic).toBeNull()
     expect(feature!.dueDate).toBe('2026-03-01')
@@ -85,6 +88,16 @@ describe('parseFeatureFile', () => {
   })
 
   describe('null / missing field handling', () => {
+    it('returns null storyPoints when frontmatter value is null', () => {
+      const content = makeFrontmatter({ storyPoints: 'null' }) + ''
+      expect(parseFeatureFile(content, FIXTURE_PATH)!.storyPoints).toBeNull()
+    })
+
+    it('returns null storyPoints when frontmatter value is invalid', () => {
+      const content = makeFrontmatter({ storyPoints: '"abc"' }) + ''
+      expect(parseFeatureFile(content, FIXTURE_PATH)!.storyPoints).toBeNull()
+    })
+
     it('returns null assignee when frontmatter value is null', () => {
       const content = makeFrontmatter({ assignee: 'null' }) + ''
       const feature = parseFeatureFile(content, FIXTURE_PATH)!
@@ -173,7 +186,8 @@ describe('serializeFeature', () => {
   })
 
   it('writes null fields as literal null (not quoted "null")', () => {
-    const output = serializeFeature(makeFeature({ assignee: null, dueDate: null, completedAt: null }))
+    const output = serializeFeature(makeFeature({ storyPoints: null, assignee: null, dueDate: null, completedAt: null }))
+    expect(output).toContain('storyPoints: null')
     expect(output).toContain('assignee: null')
     expect(output).toContain('epic: null')
     expect(output).toContain('dueDate: null')
@@ -186,6 +200,7 @@ describe('serializeFeature', () => {
     expect(output).toContain('id: "abc-123"')
     expect(output).toContain('status: "in-progress"')
     expect(output).toContain('priority: "high"')
+    expect(output).toContain('storyPoints: 3')
   })
 
   it('serializes labels as a bracketed list of quoted strings', () => {
@@ -219,6 +234,7 @@ describe('round-trip: serializeFeature → parseFeatureFile', () => {
     expect(recovered!.id).toBe(original.id)
     expect(recovered!.status).toBe(original.status)
     expect(recovered!.priority).toBe(original.priority)
+    expect(recovered!.storyPoints).toBe(original.storyPoints)
     expect(recovered!.assignee).toBe(original.assignee)
     expect(recovered!.epic).toBe(original.epic)
     expect(recovered!.dueDate).toBe(original.dueDate)
@@ -232,9 +248,10 @@ describe('round-trip: serializeFeature → parseFeatureFile', () => {
   })
 
   it('round-trips a feature with all nullable fields set to null', () => {
-    const original = makeFeature({ assignee: null, dueDate: null, completedAt: null, labels: [] })
+    const original = makeFeature({ storyPoints: null, assignee: null, dueDate: null, completedAt: null, labels: [] })
     const recovered = parseFeatureFile(serializeFeature(original), original.filePath)!
 
+    expect(recovered.storyPoints).toBeNull()
     expect(recovered.assignee).toBeNull()
     expect(recovered.dueDate).toBeNull()
     expect(recovered.completedAt).toBeNull()

--- a/tests/webview/components/FeatureCard.test.tsx
+++ b/tests/webview/components/FeatureCard.test.tsx
@@ -27,6 +27,7 @@ const defaultSettings: CardDisplaySettings = {
   showEpic: true,
   showBuildWithAI: true,
   showFileName: false,
+  pointsLabel: 'Story points',
   compactMode: false,
   markdownEditorMode: false,
   defaultPriority: 'medium',
@@ -42,6 +43,7 @@ function makeFeature(overrides: Partial<Feature> = {}): Feature {
     id: 'card-1',
     status: 'todo',
     priority: 'high',
+    storyPoints: null,
     assignee: 'lucio',
     epic: null,
     dueDate: null,
@@ -183,6 +185,20 @@ describe('FeatureCard — assignee', () => {
     setSettings({ showAssignee: true })
     render(<FeatureCard feature={makeFeature({ assignee: 'John Doe' })} onClick={() => {}} />)
     expect(screen.getByText('JD')).toBeInTheDocument()
+  })
+})
+
+describe('FeatureCard — story points', () => {
+  it('shows story points when value is 0', () => {
+    setSettings()
+    render(<FeatureCard feature={makeFeature({ storyPoints: 0 })} onClick={() => {}} />)
+    expect(screen.getByText('0')).toBeInTheDocument()
+  })
+
+  it('hides story points when value is null', () => {
+    setSettings()
+    render(<FeatureCard feature={makeFeature({ storyPoints: null })} onClick={() => {}} />)
+    expect(screen.queryByText('0')).not.toBeInTheDocument()
   })
 })
 

--- a/tests/webview/components/KanbanBoard.test.tsx
+++ b/tests/webview/components/KanbanBoard.test.tsx
@@ -42,6 +42,7 @@ function makeFeature(overrides: Partial<Feature> = {}): Feature {
     id: 'feat-1',
     status: 'backlog',
     priority: 'medium',
+    storyPoints: null,
     assignee: null,
     epic: null,
     dueDate: null,

--- a/tests/webview/components/LabelManager.test.tsx
+++ b/tests/webview/components/LabelManager.test.tsx
@@ -36,6 +36,7 @@ function makeFeature(overrides: Partial<Feature> = {}): Feature {
     id: 'feat-1',
     status: 'todo',
     priority: 'medium',
+    storyPoints: null,
     assignee: null,
     epic: null,
     dueDate: null,

--- a/tests/webview/store.test.ts
+++ b/tests/webview/store.test.ts
@@ -17,6 +17,7 @@ function makeFeature(overrides: Partial<Feature> = {}): Feature {
     id: 'f1',
     status: 'todo',
     priority: 'medium',
+    storyPoints: null,
     assignee: null,
     epic: null,
     dueDate: null,


### PR DESCRIPTION
- Added story points to cards/frontmatter and made the label configurable via `kanban-markdown.pointsLabel` (default: `Story points`).
- Updated column headers to show card count + points total for currently rendered (filtered) cards.
- Added hover breakdowns by assignee for both card count and points total, sorted high-to-low (alphabetical tie-break).
- Replaced the old “N days ago” footer display with story points on cards.
- Fixed merge issues and removed duplicate Epic field in the card editor.

## Key changes
- **Data model/frontmatter**
  - Added `storyPoints: number | null` in shared types/frontmatter parse+serialize.
  - Supports `null`, `0`, and positive integers.
- **Settings**
  - Added `kanban-markdown.pointsLabel` to extension settings.
  - Wired through extension → webview state.
- **UI**
  - Card footer now shows story points (if null, hidden).
  - Editor/create dialogs include story points input.
  - Column badges show totals and hover breakdown tooltips.

## Screenshots
Cards have points/hours values in bottom right corner.
<img width="301" height="283" alt="image" src="https://github.com/user-attachments/assets/6eb59ba2-5849-4ba0-b4ca-8017bd167567" />

Editor lets you enter a number
<img width="354" height="262" alt="image" src="https://github.com/user-attachments/assets/ed026b42-4441-45c2-9e4e-5befc3baac86" />

Not all teams use "Story points". Some teams use "Hours" or "Days" perhaps. So you can customize what the text is here.
<img width="484" height="139" alt="image" src="https://github.com/user-attachments/assets/51683fc6-91e2-46c8-8628-2951ac096fd7" />

Hovering your mouse over the column points sum will give you a breakdown report per person.
<img width="395" height="264" alt="image" src="https://github.com/user-attachments/assets/ab1c6484-cad3-49ee-828a-16a458e8805e" />

I snuck in the breakdown for card count too.
<img width="319" height="144" alt="image" src="https://github.com/user-attachments/assets/7e5c29dd-0f72-4b67-9861-7d294733f853" />


