### PR TITLE
feat: add deterministic assignee colors across cards and editor

### DIFF
--- a/src/shared/assigneeColor.ts
+++ b/src/shared/assigneeColor.ts
@@ -1,0 +1,36 @@
+import { fnv1aHash32, hsl } from './colorUtils'
+
+export interface AssigneeThemeColors {
+  badgeBackground: string
+  badgeForeground: string
+  nameForeground: string
+}
+
+/**
+ * Deterministic color theme for assignee badges + labels.
+ * `isDark` should match the board/editor theme.
+ */
+export function assigneeThemeFromName(assigneeName: string, isDark: boolean): AssigneeThemeColors {
+  const key = assigneeName.trim().toLowerCase()
+  const h = fnv1aHash32(key)
+  const hue = h % 360
+  const sat = 42 + ((h >>> 8) % 18) // 42-59
+
+  if (isDark) {
+    const badgeL = 34 + ((h >>> 16) % 12) // 34-45
+    const fgL = 88 + ((h >>> 20) % 8) // 88-95
+    return {
+      badgeBackground: hsl(hue, sat, badgeL),
+      badgeForeground: hsl(hue, 92, fgL),
+      nameForeground: hsl(hue, 74, Math.max(70, fgL - 8))
+    }
+  }
+
+  const badgeL = 82 + ((h >>> 16) % 12) // 82-93
+  const fgL = 20 + ((h >>> 20) % 12) // 20-31
+  return {
+    badgeBackground: hsl(hue, sat, badgeL),
+    badgeForeground: hsl(hue, 72, fgL),
+    nameForeground: hsl(hue, 58, Math.min(42, fgL + 10))
+  }
+}

--- a/src/shared/colorUtils.ts
+++ b/src/shared/colorUtils.ts
@@ -1,0 +1,14 @@
+/** FNV-1a 32-bit hash for deterministic color generation */
+export function fnv1aHash32(value: string): number {
+  let h = 2166136261 >>> 0
+  for (let i = 0; i < value.length; i++) {
+    h ^= value.charCodeAt(i)
+    h = Math.imul(h, 16777619) >>> 0
+  }
+  return h >>> 0
+}
+
+/** Formats an HSL color string */
+export function hsl(hue: number, saturation: number, lightness: number): string {
+  return `hsl(${hue}, ${saturation}%, ${lightness}%)`
+}

--- a/src/shared/epicColor.ts
+++ b/src/shared/epicColor.ts
@@ -1,12 +1,4 @@
-/** FNV-1a 32-bit — deterministic hash for epic names */
-function hashEpicName(str: string): number {
-  let h = 2166136261 >>> 0
-  for (let i = 0; i < str.length; i++) {
-    h ^= str.charCodeAt(i)
-    h = Math.imul(h, 16777619) >>> 0
-  }
-  return h >>> 0
-}
+import { fnv1aHash32, hsl } from './colorUtils'
 
 export interface EpicThemeColors {
   /** Soft pastel for borders / outlines */
@@ -21,7 +13,7 @@ export interface EpicThemeColors {
  */
 export function epicThemeFromName(epicName: string, isDark: boolean): EpicThemeColors {
   const key = epicName.trim()
-  const h = hashEpicName(key)
+  const h = fnv1aHash32(key)
   const hue = h % 360
   const sat = 34 + ((h >>> 8) % 22) // 34–55
 
@@ -30,8 +22,8 @@ export function epicThemeFromName(epicName: string, isDark: boolean): EpicThemeC
     const fgSat = Math.min(55, sat + 14)
     const fgL = 72 + ((h >>> 20) % 12) // 72–83
     return {
-      border: `hsl(${hue}, ${sat}%, ${borderL}%)`,
-      foreground: `hsl(${hue}, ${fgSat}%, ${fgL}%)`
+      border: hsl(hue, sat, borderL),
+      foreground: hsl(hue, fgSat, fgL)
     }
   }
 
@@ -39,7 +31,7 @@ export function epicThemeFromName(epicName: string, isDark: boolean): EpicThemeC
   const fgSat = Math.min(55, sat + 12)
   const fgL = 34 + ((h >>> 20) % 10) // 34–43 — readable on light cards
   return {
-    border: `hsl(${hue}, ${sat}%, ${borderL}%)`,
-    foreground: `hsl(${hue}, ${fgSat}%, ${fgL}%)`
+    border: hsl(hue, sat, borderL),
+    foreground: hsl(hue, fgSat, fgL)
   }
 }

--- a/src/webview/components/AssigneeInput.tsx
+++ b/src/webview/components/AssigneeInput.tsx
@@ -1,4 +1,5 @@
 import { useState, useRef, useMemo } from 'react'
+import { assigneeThemeFromName } from '../../shared/assigneeColor'
 import { useStore } from '../store'
 import { t } from '../lib/i18n'
 
@@ -7,6 +8,7 @@ export function AssigneeInput({ value, onChange }: { value: string; onChange: (v
   const [isFocused, setIsFocused] = useState(false)
   const inputRef = useRef<HTMLInputElement>(null)
   const features = useStore(s => s.features)
+  const isDarkMode = useStore(s => s.isDarkMode)
 
   const existingAssignees = useMemo(() => {
     const assignees = new Set<string>()
@@ -34,6 +36,7 @@ export function AssigneeInput({ value, onChange }: { value: string; onChange: (v
         .toUpperCase()
         .slice(0, 2)
     : null
+  const assigneeTheme = value.trim() ? assigneeThemeFromName(value, isDarkMode) : null
 
   return (
     <div className="relative flex-1 min-w-0">
@@ -44,10 +47,17 @@ export function AssigneeInput({ value, onChange }: { value: string; onChange: (v
         {initials && (
           <span
             className="shrink-0 w-4 h-4 rounded-full flex items-center justify-center text-[8px] font-bold"
-            style={{
-              background: 'var(--vscode-badge-background)',
-              color: 'var(--vscode-badge-foreground)',
-            }}
+            style={
+              assigneeTheme
+                ? {
+                    background: assigneeTheme.badgeBackground,
+                    color: assigneeTheme.badgeForeground
+                  }
+                : {
+                    background: 'var(--vscode-badge-background)',
+                    color: 'var(--vscode-badge-foreground)'
+                  }
+            }
           >
             {initials}
           </span>
@@ -72,7 +82,9 @@ export function AssigneeInput({ value, onChange }: { value: string; onChange: (v
             border: '1px solid var(--vscode-dropdown-border, var(--vscode-panel-border))',
           }}
         >
-          {suggestions.map(assignee => (
+          {suggestions.map(assignee => {
+            const suggestionTheme = assigneeThemeFromName(assignee, isDarkMode)
+            return (
             <button
               key={assignee}
               type="button"
@@ -88,8 +100,8 @@ export function AssigneeInput({ value, onChange }: { value: string; onChange: (v
               <span
                 className="shrink-0 w-4 h-4 rounded-full flex items-center justify-center text-[8px] font-bold"
                 style={{
-                  background: 'var(--vscode-badge-background)',
-                  color: 'var(--vscode-badge-foreground)',
+                  background: suggestionTheme.badgeBackground,
+                  color: suggestionTheme.badgeForeground
                 }}
               >
                 {assignee
@@ -99,9 +111,10 @@ export function AssigneeInput({ value, onChange }: { value: string; onChange: (v
                   .toUpperCase()
                   .slice(0, 2)}
               </span>
-              <span>{assignee}</span>
+              <span style={{ color: suggestionTheme.nameForeground }}>{assignee}</span>
             </button>
-          ))}
+            )
+          })}
         </div>
       )}
     </div>

--- a/src/webview/components/FeatureCard.tsx
+++ b/src/webview/components/FeatureCard.tsx
@@ -2,6 +2,7 @@ import { Calendar, Check, FileText, Layers } from 'lucide-react'
 import { getTitleFromContent } from '../../shared/types'
 import type { Feature, Priority } from '../../shared/types'
 import { epicThemeFromName } from '../../shared/epicColor'
+import { assigneeThemeFromName } from '../../shared/assigneeColor'
 import { useStore } from '../store'
 import { t } from '../lib/i18n'
 
@@ -88,7 +89,8 @@ export function FeatureCard({ feature, onClick, isDragging }: FeatureCardProps) 
 
   const epicTrimmed = feature.epic?.trim()
   const epicTheme = epicTrimmed ? epicThemeFromName(epicTrimmed, isDarkMode) : null
-
+  const assigneeTrimmed = feature.assignee?.trim()
+  const assigneeTheme = assigneeTrimmed ? assigneeThemeFromName(assigneeTrimmed, isDarkMode) : null
   return (
     <div
       onClick={onClick}
@@ -164,14 +166,20 @@ export function FeatureCard({ feature, onClick, isDragging }: FeatureCardProps) 
       </div>
 
       {/* Footer */}
-      <div className="flex items-center justify-between text-xs mt-auto">
-        <div className="flex items-center gap-1">
-          {cardSettings.showAssignee && feature.assignee && feature.assignee !== 'null' && (
-            <div className="flex items-center gap-1.5 text-zinc-500 dark:text-zinc-400">
-              <span className="shrink-0 w-4 h-4 rounded-full flex items-center justify-center text-[8px] font-bold bg-zinc-200 dark:bg-zinc-600 text-zinc-700 dark:text-zinc-300">
-                {feature.assignee.split(/\s+/).map((w: string) => w[0]).join('').toUpperCase().slice(0, 2)}
+      <div className="flex items-center justify-between gap-2 text-xs mt-auto">
+        <div className="flex items-center gap-1 flex-1 min-w-0">
+          {cardSettings.showAssignee && assigneeTrimmed && assigneeTrimmed !== 'null' && assigneeTheme && (
+            <div className="flex items-center gap-1.5 min-w-0" style={{ color: assigneeTheme.nameForeground }}>
+              <span
+                className="shrink-0 w-4 h-4 rounded-full flex items-center justify-center text-[8px] font-bold"
+                style={{
+                  background: assigneeTheme.badgeBackground,
+                  color: assigneeTheme.badgeForeground
+                }}
+              >
+                {assigneeTrimmed.split(/\s+/).map((w: string) => w[0]).join('').toUpperCase().slice(0, 2)}
               </span>
-              <span>{feature.assignee}</span>
+              <span className="truncate">{assigneeTrimmed}</span>
             </div>
           )}
         </div>

--- a/tests/shared/assigneeColor.test.ts
+++ b/tests/shared/assigneeColor.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest'
+import { assigneeThemeFromName } from '../../src/shared/assigneeColor'
+
+describe('assigneeThemeFromName', () => {
+  it('returns the same colors for the same assignee name', () => {
+    const a = assigneeThemeFromName('Jane Doe', false)
+    const b = assigneeThemeFromName('Jane Doe', false)
+    expect(a).toEqual(b)
+  })
+
+  it('differs between assignee names', () => {
+    const a = assigneeThemeFromName('Alice', false)
+    const b = assigneeThemeFromName('Bob', false)
+    expect(a.badgeBackground).not.toBe(b.badgeBackground)
+  })
+
+  it('normalizes casing and whitespace for hashing', () => {
+    expect(assigneeThemeFromName('  Jane DOE  ', true)).toEqual(assigneeThemeFromName('jane doe', true))
+  })
+
+  it('produces hsl strings', () => {
+    const colors = assigneeThemeFromName('My Assignee', true)
+    expect(colors.badgeBackground).toMatch(/^hsl\(\d+, \d+%?, \d+%?\)$/)
+    expect(colors.badgeForeground).toMatch(/^hsl\(\d+, \d+%?, \d+%?\)$/)
+    expect(colors.nameForeground).toMatch(/^hsl\(\d+, \d+%?, \d+%?\)$/)
+  })
+})

--- a/tests/shared/colorUtils.test.ts
+++ b/tests/shared/colorUtils.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest'
+import { fnv1aHash32, hsl } from '../../src/shared/colorUtils'
+
+describe('fnv1aHash32', () => {
+  it('is deterministic for the same input', () => {
+    expect(fnv1aHash32('Epic Alpha')).toBe(fnv1aHash32('Epic Alpha'))
+  })
+
+  it('produces different values for different input', () => {
+    expect(fnv1aHash32('Epic Alpha')).not.toBe(fnv1aHash32('Epic Beta'))
+  })
+})
+
+describe('hsl', () => {
+  it('formats hsl values consistently', () => {
+    expect(hsl(120, 55, 40)).toBe('hsl(120, 55%, 40%)')
+  })
+})


### PR DESCRIPTION
Assignees were visually neutral, which made it slower to scan a board and quickly tell who owns what. Deterministic assignee colors improve at-a-glance recognition.

- Add deterministic, name-based assignee color theming so assignees are easier to distinguish at a glance.
- Apply assignee colors in both the Kanban card footer and the assignee input/suggestions for a consistent browse/edit experience.
- Extract shared color helpers (`fnv1aHash32`, `hsl`) and reuse them in both epic and assignee color modules to reduce duplication.
- Add unit tests for assignee color generation and shared color utilities.