### PR TITLE
fix: improve column nested menu behavior

### DIFF
--- a/package.json
+++ b/package.json
@@ -346,6 +346,7 @@
     "vitest": "~4.0.18"
   },
   "dependencies": {
+    "@base-ui/react": "^1.5.0",
     "@tiptap/extension-placeholder": "^3.15.3",
     "@tiptap/pm": "^3.15.3",
     "@tiptap/react": "^3.15.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@base-ui/react':
+        specifier: ^1.5.0
+        version: 1.5.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@tiptap/extension-placeholder':
         specifier: ^3.15.3
         version: 3.20.0(@tiptap/extensions@3.20.0(@tiptap/core@3.20.0(@tiptap/pm@3.20.0))(@tiptap/pm@3.20.0))
@@ -304,6 +307,33 @@ packages:
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
+
+  '@base-ui/react@1.5.0':
+    resolution: {integrity: sha512-z1gSAlced1yY+iM+mHDEtIkD8UI3Ebs52MuBPxvV6f5hRutk+xvCH/wuB7hDqDzK9JG5FoMz5nhrqtSs1wjt1A==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      '@date-fns/tz': ^1.2.0
+      '@types/react': ^17 || ^18 || ^19
+      date-fns: ^4.0.0
+      react: ^17 || ^18 || ^19
+      react-dom: ^17 || ^18 || ^19
+    peerDependenciesMeta:
+      '@date-fns/tz':
+        optional: true
+      '@types/react':
+        optional: true
+      date-fns:
+        optional: true
+
+  '@base-ui/utils@0.2.9':
+    resolution: {integrity: sha512-x/PDDCYzoqPpjrdyb3VcyylTI2IjUXEtYDGi5foh7KsnmNJIIaVwA2GLgDH1dps1GgXiJbA60hM+AyuTfQzIvw==}
+    peerDependencies:
+      '@types/react': ^17 || ^18 || ^19
+      react: ^17 || ^18 || ^19
+      react-dom: ^17 || ^18 || ^19
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
 
   '@bcoe/v8-coverage@1.0.2':
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
@@ -835,11 +865,26 @@ packages:
   '@floating-ui/core@1.7.4':
     resolution: {integrity: sha512-C3HlIdsBxszvm5McXlB8PeOEWfBhcGBTZGkGlWc2U0KFY5IwG5OQEuQ8rq52DZmcHDlPLd+YFBK+cZcytwIFWg==}
 
+  '@floating-ui/core@1.7.5':
+    resolution: {integrity: sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==}
+
   '@floating-ui/dom@1.7.5':
     resolution: {integrity: sha512-N0bD2kIPInNHUHehXhMke1rBGs1dwqvC9O9KYMyyjK7iXt7GAhnro7UlcuYcGdS/yYOlq0MAVgrow8IbWJwyqg==}
 
+  '@floating-ui/dom@1.7.6':
+    resolution: {integrity: sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==}
+
+  '@floating-ui/react-dom@2.1.8':
+    resolution: {integrity: sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
   '@floating-ui/utils@0.2.10':
     resolution: {integrity: sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==}
+
+  '@floating-ui/utils@0.2.11':
+    resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -3431,6 +3476,9 @@ packages:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
 
+  reselect@5.2.0:
+    resolution: {integrity: sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw==}
+
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
@@ -4414,6 +4462,29 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
+  '@base-ui/react@1.5.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@base-ui/utils': 0.2.9(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@floating-ui/react-dom': 2.1.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@floating-ui/utils': 0.2.11
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      use-sync-external-store: 1.6.0(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.28
+
+  '@base-ui/utils@0.2.9(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@floating-ui/utils': 0.2.11
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      reselect: 5.2.0
+      use-sync-external-store: 1.6.0(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.28
+
   '@bcoe/v8-coverage@1.0.2': {}
 
   '@bramus/specificity@2.4.2':
@@ -4727,14 +4798,31 @@ snapshots:
       '@floating-ui/utils': 0.2.10
     optional: true
 
+  '@floating-ui/core@1.7.5':
+    dependencies:
+      '@floating-ui/utils': 0.2.11
+
   '@floating-ui/dom@1.7.5':
     dependencies:
       '@floating-ui/core': 1.7.4
       '@floating-ui/utils': 0.2.10
     optional: true
 
+  '@floating-ui/dom@1.7.6':
+    dependencies:
+      '@floating-ui/core': 1.7.5
+      '@floating-ui/utils': 0.2.11
+
+  '@floating-ui/react-dom@2.1.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@floating-ui/dom': 1.7.6
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
   '@floating-ui/utils@0.2.10':
     optional: true
+
+  '@floating-ui/utils@0.2.11': {}
 
   '@humanfs/core@0.19.1': {}
 
@@ -7713,6 +7801,8 @@ snapshots:
   require-directory@2.1.1: {}
 
   require-from-string@2.0.2: {}
+
+  reselect@5.2.0: {}
 
   resolve-from@4.0.0: {}
 

--- a/src/webview/components/KanbanColumn.tsx
+++ b/src/webview/components/KanbanColumn.tsx
@@ -1,5 +1,6 @@
 import { Plus, ChevronLeft, MoreVertical, ChevronRight } from 'lucide-react'
-import { useState, useRef, useEffect } from 'react'
+import { Menu } from '@base-ui/react/menu'
+import { useState } from 'react'
 import { FeatureCard } from './FeatureCard'
 import type { Feature, KanbanColumn as KanbanColumnType } from '../../shared/types'
 import type { LayoutMode } from '../store'
@@ -46,19 +47,15 @@ export function KanbanColumn({
   const isVertical = layout === 'vertical'
   const isDropTarget = dropTarget && dropTarget.columnId === column.id
   const [menuOpen, setMenuOpen] = useState(false)
-  const [submenuOpen, setSubmenuOpen] = useState(false)
-  const menuRef = useRef<HTMLDivElement>(null)
-
-  useEffect(() => {
-    if (!menuOpen) return
-    const handleClickOutside = (e: MouseEvent) => {
-      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
-        setMenuOpen(false)
-      }
-    }
-    document.addEventListener('mousedown', handleClickOutside)
-    return () => document.removeEventListener('mousedown', handleClickOutside)
-  }, [menuOpen])
+  const hasCards = features.length > 0
+  const menuPopupClassName =
+    'z-50 min-w-[220px] bg-white dark:bg-zinc-800 border border-zinc-200 ' +
+    'dark:border-zinc-700 rounded-md shadow-lg py-1 text-zinc-700 dark:text-zinc-200'
+  const menuItemClassName =
+    'w-full px-3 py-2 text-sm text-left outline-none hover:bg-zinc-100 ' +
+    'dark:hover:bg-zinc-700 data-[highlighted]:bg-zinc-100 ' +
+    'dark:data-[highlighted]:bg-zinc-700 data-[disabled]:opacity-40 ' +
+    'data-[disabled]:pointer-events-none'
 
   return (
     <div
@@ -94,53 +91,64 @@ export function KanbanColumn({
           >
             <Plus size={16} className="text-zinc-500" />
           </button>
-          <div ref={menuRef} className="relative flex">
-            <button
-              onClick={() => setMenuOpen((o) => !o)}
+          <Menu.Root modal={false} open={menuOpen} onOpenChange={setMenuOpen}>
+            <Menu.Trigger
+              onClick={() => setMenuOpen((open) => !open)}
               className="p-0.5 rounded hover:bg-zinc-200 dark:hover:bg-zinc-700 transition-colors cursor-pointer"
               title={t('column.options')}
             >
               <MoreVertical size={16} className="text-zinc-500" />
-            </button>
-            {menuOpen && (
-              <div className="absolute right-0 top-full mt-1 z-50 min-w-[200px] bg-white dark:bg-zinc-800 border border-zinc-200 dark:border-zinc-700 rounded-md shadow-lg py-1">
-                <div
-                  className={`relative ${features.length === 0 ? 'opacity-40 pointer-events-none' : ''}`}
-                  onMouseEnter={() => setSubmenuOpen(true)}
-                  onMouseLeave={() => setSubmenuOpen(false)}
-                >
-                  <button
-                    className="w-full text-left px-3 py-1.5 text-sm text-zinc-700 dark:text-zinc-200 hover:bg-zinc-100 dark:hover:bg-zinc-700 flex items-center justify-between gap-2"
-                  >
-                    <span>{t('column.moveAllCards')}</span>
-                    <ChevronRight size={14} className="text-zinc-400 flex-shrink-0" />
-                  </button>
-                  {submenuOpen && (
-                    <div className="absolute left-full top-0 ml-0.5 z-50 min-w-[160px] bg-white dark:bg-zinc-800 border border-zinc-200 dark:border-zinc-700 rounded-md shadow-lg py-1">
-                      {otherColumns.map((col) => (
-                        <button
-                          key={col.id}
-                          className="w-full text-left px-3 py-1.5 text-sm text-zinc-700 dark:text-zinc-200 hover:bg-zinc-100 dark:hover:bg-zinc-700 flex items-center gap-2"
-                          onClick={() => { onMoveAllCards(col.id); setMenuOpen(false); setSubmenuOpen(false) }}
-                        >
-                          <div className="w-2 h-2 rounded-full flex-shrink-0" style={{ backgroundColor: col.color }} />
-                          {col.name}
-                        </button>
-                      ))}
-                    </div>
+            </Menu.Trigger>
+            <Menu.Portal>
+              <Menu.Positioner align="end" sideOffset={4}>
+                <Menu.Popup className={menuPopupClassName}>
+                  <Menu.SubmenuRoot>
+                    <Menu.SubmenuTrigger
+                      className={`${menuItemClassName} flex items-center justify-between gap-2`}
+                      disabled={!hasCards}
+                      openOnHover
+                      delay={0}
+                      closeDelay={250}
+                    >
+                      <span>{t('column.moveAllCards')}</span>
+                      <ChevronRight size={14} className="text-zinc-400 flex-shrink-0" />
+                    </Menu.SubmenuTrigger>
+                    <Menu.Portal>
+                      <Menu.Positioner side="right" align="start" sideOffset={-4}>
+                        <Menu.Popup className={`${menuPopupClassName} min-w-[180px]`}>
+                          {otherColumns.map((col) => (
+                            <Menu.Item
+                              key={col.id}
+                              className={`${menuItemClassName} flex items-center gap-2`}
+                              onClick={() => {
+                                onMoveAllCards(col.id)
+                                setMenuOpen(false)
+                              }}
+                            >
+                              <div className="w-2 h-2 rounded-full flex-shrink-0" style={{ backgroundColor: col.color }} />
+                              {col.name}
+                            </Menu.Item>
+                          ))}
+                        </Menu.Popup>
+                      </Menu.Positioner>
+                    </Menu.Portal>
+                  </Menu.SubmenuRoot>
+                  {onArchiveAllCards && (
+                    <Menu.Item
+                      className={menuItemClassName}
+                      disabled={!hasCards}
+                      onClick={() => {
+                        onArchiveAllCards()
+                        setMenuOpen(false)
+                      }}
+                    >
+                      {t('column.archiveAllCards')}
+                    </Menu.Item>
                   )}
-                </div>
-                {onArchiveAllCards && (
-                  <button
-                    className={`w-full text-left px-3 py-1.5 text-sm text-zinc-700 dark:text-zinc-200 hover:bg-zinc-100 dark:hover:bg-zinc-700 ${features.length === 0 ? 'opacity-40 pointer-events-none' : ''}`}
-                    onClick={() => { onArchiveAllCards(); setMenuOpen(false) }}
-                  >
-                    {t('column.archiveAllCards')}
-                  </button>
-                )}
-              </div>
-            )}
-          </div>
+                </Menu.Popup>
+              </Menu.Positioner>
+            </Menu.Portal>
+          </Menu.Root>
         </div>
       </div>
 

--- a/tests/webview/components/KanbanBoard.test.tsx
+++ b/tests/webview/components/KanbanBoard.test.tsx
@@ -243,13 +243,13 @@ describe('KanbanBoard — moveAllCards', () => {
     const menuBtn = within(backlogSection).getByTitle('Column options')
     await user.click(menuBtn)
 
-    // Trigger mouseEnter on the "Move all cards" wrapper div to open submenu
-    const moveAllWrapper = screen.getByText('Move all cards in this list').closest('div')!
+    // Trigger mouseEnter on the "Move all cards" menu item to open submenu
+    const moveAllWrapper = await screen.findByRole('menuitem', {
+      name: 'Move all cards in this list'
+    })
     fireEvent.mouseEnter(moveAllWrapper)
 
-    // Click 'To Do' as the target — scoped to the Backlog section to avoid
-    // matching the 'Collapse To Do' / 'Add to To Do' buttons in other columns
-    await user.click(within(backlogSection).getByRole('button', { name: 'To Do' }))
+    await user.click(await screen.findByRole('menuitem', { name: 'To Do' }))
 
     expect(mockPostMessage).toHaveBeenCalledWith({
       type: 'moveAllCards',
@@ -269,10 +269,12 @@ describe('KanbanBoard — moveAllCards', () => {
     const menuBtn = within(backlogSection).getByTitle('Column options')
     await user.click(menuBtn)
 
-    const moveAllWrapper = screen.getByText('Move all cards in this list').closest('div')!
+    const moveAllWrapper = await screen.findByRole('menuitem', {
+      name: 'Move all cards in this list'
+    })
     fireEvent.mouseEnter(moveAllWrapper)
 
-    await user.click(within(backlogSection).getByRole('button', { name: 'To Do' }))
+    await user.click(await screen.findByRole('menuitem', { name: 'To Do' }))
 
     expect(mockPostMessage).toHaveBeenCalledWith({
       type: 'moveAllCards',
@@ -300,7 +302,7 @@ describe('KanbanBoard — archiveAllCards', () => {
     const menuBtn = within(doneSection).getByTitle('Column options')
     await user.click(menuBtn)
 
-    await user.click(screen.getByRole('button', { name: /archive all cards/i }))
+    await user.click(await screen.findByRole('menuitem', { name: /archive all cards/i }))
 
     expect(mockPostMessage).toHaveBeenCalledWith({
       type: 'archiveAllCards',


### PR DESCRIPTION
Hi,

I’ve been using this plugin for quite some time now, and I wanted to make my first contribution regarding menu behavior. When I move the cursor toward the submenu items under “Move all cards in this list,” the submenu often disappears before I can select an option.

The only significant change I’ve made is adding base-ui as a dependency. I didn’t want to create custom code for the menu behavior. Base-ui is a great option that I’ve used for my other projects as well.

Best,

## Summary

- Replace the custom column options submenu with Base UI nested menu primitives
- Improve hover behavior for "Move all cards in this list"
- Preserve existing move-all and archive-all behavior
- Update webview tests to use menuitem roles

## Verification

- pnpm install --frozen-lockfile
- pnpm test -- tests/webview/components/KanbanBoard.test.tsx
- pnpm typecheck
- pnpm lint
- pnpm build

## Notes

This adds `@base-ui/react` for nested menu behavior. The webview bundle increases because Base UI brings menu positioning and interaction primitives, but only the menu-related modules are included through tree shaking.