### PR TITLE
Fix Build with AI terminal launches

### DIFF
--- a/src/extension/FeatureHeaderProvider.ts
+++ b/src/extension/FeatureHeaderProvider.ts
@@ -2,7 +2,8 @@ import * as vscode from 'vscode'
 import * as crypto from 'crypto'
 import * as path from 'path'
 import type { FeatureFrontmatter, EditorExtensionMessage, EditorWebviewMessage } from '../shared/editorTypes'
-import type { FeatureStatus, Priority, AIAgent } from '../shared/types'
+import type { FeatureStatus, Priority } from '../shared/types'
+import { buildAITerminalLaunch, buildFeaturePrompt, normalizeAIAgent, normalizeAIPermissionMode } from './aiTerminal'
 
 /**
  * Provides a webview panel that shows feature metadata (frontmatter) as a header.
@@ -108,61 +109,22 @@ export class FeatureHeaderProvider implements vscode.WebviewViewProvider {
           const titleMatch = docContent.match(/^#\s+(.+)$/m)
           const title = titleMatch ? titleMatch[1].trim() : 'Untitled'
 
-          const labels = fm.labels.length > 0 ? ` [${fm.labels.join(', ')}]` : ''
-          const description = docContent.replace(/\n/g, ' ').replace(/\s+/g, ' ').trim()
-          const shortDesc = description.length > 200 ? description.substring(0, 200) + '...' : description
+          const prompt = buildFeaturePrompt({
+            title,
+            priority: fm.priority,
+            labels: fm.labels,
+            content: docContent,
+            filePath: this._currentDocument.uri.fsPath
+          })
 
-          const prompt = `Implement this feature: "${title}" (${fm.priority} priority)${labels}. ${shortDesc} See full details in: ${this._currentDocument.uri.fsPath}`
-
-          const agent: AIAgent = message.agent || 'claude'
-          const permissionMode = message.permissionMode || 'default'
-
-          let args: string[]
-
-          switch (agent) {
-            case 'claude': {
-              args = []
-              if (permissionMode !== 'default') {
-                args.push('--permission-mode', permissionMode)
-              }
-              args.push(prompt)
-              break
-            }
-            case 'codex': {
-              const approvalMap: Record<string, string> = {
-                'default': 'ask',
-                'plan': 'ask',
-                'acceptEdits': 'auto',
-                'bypassPermissions': 'full-auto'
-              }
-              const approvalMode = approvalMap[permissionMode] || 'suggest'
-              args = ['--ask-for-approval', approvalMode, prompt]
-              break
-            }
-            case 'opencode': {
-              args = [prompt]
-              break
-            }
-            case 'copilot': {
-              args = [prompt]
-              break
-            }
-            default:
-              args = [prompt]
-          }
-
-          const agentNames: Record<string, string> = {
-            'claude': 'Claude Code',
-            'copilot': 'GitHub Copilot',
-            'codex': 'Codex',
-            'opencode': 'OpenCode'
-          }
+          const agent = normalizeAIAgent(message.agent)
+          const permissionMode = normalizeAIPermissionMode(message.permissionMode)
+          const launch = buildAITerminalLaunch(agent, permissionMode, prompt)
           const terminal = vscode.window.createTerminal({
-            name: agentNames[agent] || 'AI Agent',
+            ...launch,
             cwd: vscode.workspace.workspaceFolders?.[0]?.uri.fsPath
           })
           terminal.show()
-          terminal.sendText([this._shellQuote(agent), ...args.map(a => this._shellQuote(a))].join(' '))
           break
         }
       }
@@ -337,10 +299,6 @@ export class FeatureHeaderProvider implements vscode.WebviewViewProvider {
 
   private _getNonce(): string {
     return crypto.randomBytes(24).toString('base64url')
-  }
-
-  private _shellQuote(arg: string): string {
-    return "'" + arg.replace(/'/g, "'\\''") + "'"
   }
 
   private _getHtmlForWebview(webview: vscode.Webview): string {

--- a/src/extension/KanbanPanel.ts
+++ b/src/extension/KanbanPanel.ts
@@ -8,6 +8,7 @@ import { ensureStatusSubfolders, moveFeatureFile, getFeatureFilePath, getStatusF
 import { parseFeatureFile, serializeFeature } from '../shared/featureFrontmatter'
 import { featureMatchesEpicLane } from '../shared/epicLane'
 import { t, getBundle, getEffectiveLocale, reloadBundle, getAllDefaultColumnNames, getDefaultColumnNamesForLocale } from './l10n'
+import { buildAITerminalLaunch, buildFeaturePrompt, normalizeAIAgent, normalizeAIPermissionMode } from './aiTerminal'
 
 function normalizeEpic(value: string | null | undefined): string | null {
   const t = value?.trim()
@@ -332,10 +333,6 @@ export class KanbanPanel {
 
   private _getNonce(): string {
     return crypto.randomBytes(24).toString('base64url')
-  }
-
-  private _shellQuote(arg: string): string {
-    return "'" + arg.replace(/'/g, "'\\''") + "'"
   }
 
   private _getWorkspaceFeaturesDir(): string | null {
@@ -918,63 +915,24 @@ export class KanbanPanel {
     const titleMatch = feature.content.match(/^#\s+(.+)$/m)
     const title = titleMatch ? titleMatch[1].trim() : getTitleFromContent(feature.content)
 
-    const labels = feature.labels.length > 0 ? ` [${feature.labels.join(', ')}]` : ''
-    const description = feature.content.replace(/\n/g, ' ').replace(/\s+/g, ' ').trim()
-    const shortDesc = description.length > 200 ? description.substring(0, 200) + '...' : description
-
-    const prompt = `Implement this feature: "${title}" (${feature.priority} priority)${labels}. ${shortDesc} See full details in: ${feature.filePath}`
+    const prompt = buildFeaturePrompt({
+      title,
+      priority: feature.priority,
+      labels: feature.labels,
+      content: feature.content,
+      filePath: feature.filePath
+    })
 
     // Use provided agent or fall back to config
     const config = vscode.workspace.getConfiguration('kanban-markdown')
-    const selectedAgent = agent || config.get<string>('aiAgent') || 'claude'
-    const selectedPermissionMode = permissionMode || 'default'
-
-    let args: string[]
-
-    switch (selectedAgent) {
-      case 'claude': {
-        args = []
-        if (selectedPermissionMode !== 'default') {
-          args.push('--permission-mode', selectedPermissionMode)
-        }
-        args.push(prompt)
-        break
-      }
-      case 'codex': {
-        const approvalMap: Record<string, string> = {
-          'default': 'ask',
-          'plan': 'ask',
-          'acceptEdits': 'auto',
-          'bypassPermissions': 'full-auto'
-        }
-        const approvalMode = approvalMap[selectedPermissionMode] || 'suggest'
-        args = ['--ask-for-approval', approvalMode, prompt]
-        break
-      }
-      case 'copilot': {
-        args = [prompt]
-        break
-      }
-      case 'opencode': {
-        args = [prompt]
-        break
-      }
-      default:
-        args = [prompt]
-    }
-
-    const agentNames: Record<string, string> = {
-      'claude': 'Claude Code',
-      'codex': 'Codex',
-      'copilot': 'GitHub Copilot',
-      'opencode': 'OpenCode'
-    }
+    const selectedAgent = normalizeAIAgent(agent || config.get<string>('aiAgent'))
+    const selectedPermissionMode = normalizeAIPermissionMode(permissionMode)
+    const launch = buildAITerminalLaunch(selectedAgent, selectedPermissionMode, prompt)
     const terminal = vscode.window.createTerminal({
-      name: agentNames[selectedAgent] || 'AI Agent',
+      ...launch,
       cwd: vscode.workspace.workspaceFolders?.[0]?.uri.fsPath
     })
     terminal.show()
-    terminal.sendText([this._shellQuote(selectedAgent), ...args.map(a => this._shellQuote(a))].join(' '))
   }
 
   private async _deleteLabel(labelName: string): Promise<void> {

--- a/src/extension/aiTerminal.ts
+++ b/src/extension/aiTerminal.ts
@@ -77,6 +77,6 @@ export function buildAITerminalLaunch(
     case 'copilot':
       return { name: agentNames[agent], shellPath: agent, shellArgs: ['--interactive', prompt] }
     case 'opencode':
-      return { name: agentNames[agent], shellPath: agent, shellArgs: ['run', prompt] }
+      return { name: agentNames[agent], shellPath: agent, shellArgs: ['--prompt', prompt] }
   }
 }

--- a/src/extension/aiTerminal.ts
+++ b/src/extension/aiTerminal.ts
@@ -75,7 +75,7 @@ export function buildAITerminalLaunch(
       }
     }
     case 'copilot':
-      return { name: agentNames[agent], shellPath: agent, shellArgs: [prompt] }
+      return { name: agentNames[agent], shellPath: agent, shellArgs: ['--interactive', prompt] }
     case 'opencode':
       return { name: agentNames[agent], shellPath: agent, shellArgs: ['run', prompt] }
   }

--- a/src/extension/aiTerminal.ts
+++ b/src/extension/aiTerminal.ts
@@ -1,0 +1,74 @@
+import type { AIAgent, AIPermissionMode, Priority } from '../shared/types'
+
+interface FeaturePromptInput {
+  title: string
+  priority: Priority
+  labels: string[]
+  content: string
+  filePath: string
+}
+
+interface AITerminalLaunch {
+  name: string
+  shellPath: AIAgent
+  shellArgs: string[]
+}
+
+const agentNames: Record<AIAgent, string> = {
+  claude: 'Claude Code',
+  codex: 'Codex',
+  copilot: 'GitHub Copilot',
+  opencode: 'OpenCode'
+}
+
+const agents = new Set<string>(Object.keys(agentNames))
+const permissionModes = new Set<string>(['default', 'plan', 'acceptEdits', 'bypassPermissions'])
+
+export function normalizeAIAgent(value: string | undefined): AIAgent {
+  return value && agents.has(value) ? value as AIAgent : 'claude'
+}
+
+export function normalizeAIPermissionMode(value: string | undefined): AIPermissionMode {
+  return value && permissionModes.has(value) ? value as AIPermissionMode : 'default'
+}
+
+export function buildFeaturePrompt(input: FeaturePromptInput): string {
+  const labels = input.labels.length > 0 ? ` [${input.labels.join(', ')}]` : ''
+  const description = input.content.replace(/\n/g, ' ').replace(/\s+/g, ' ').trim()
+  const shortDesc = description.length > 200 ? description.substring(0, 200) + '...' : description
+
+  return `Implement this feature: "${input.title}" (${input.priority} priority)${labels}. ${shortDesc} See full details in: ${input.filePath}`
+}
+
+export function buildAITerminalLaunch(
+  agent: AIAgent,
+  permissionMode: AIPermissionMode,
+  prompt: string
+): AITerminalLaunch {
+  switch (agent) {
+    case 'claude': {
+      const shellArgs: string[] = []
+      if (permissionMode !== 'default') {
+        shellArgs.push('--permission-mode', permissionMode)
+      }
+      shellArgs.push(prompt)
+      return { name: agentNames[agent], shellPath: agent, shellArgs }
+    }
+    case 'codex': {
+      const approvalMap: Record<AIPermissionMode, string> = {
+        default: 'ask',
+        plan: 'ask',
+        acceptEdits: 'auto',
+        bypassPermissions: 'full-auto'
+      }
+      return {
+        name: agentNames[agent],
+        shellPath: agent,
+        shellArgs: ['--ask-for-approval', approvalMap[permissionMode], prompt]
+      }
+    }
+    case 'copilot':
+    case 'opencode':
+      return { name: agentNames[agent], shellPath: agent, shellArgs: [prompt] }
+  }
+}

--- a/src/extension/aiTerminal.ts
+++ b/src/extension/aiTerminal.ts
@@ -75,7 +75,8 @@ export function buildAITerminalLaunch(
       }
     }
     case 'copilot':
-    case 'opencode':
       return { name: agentNames[agent], shellPath: agent, shellArgs: [prompt] }
+    case 'opencode':
+      return { name: agentNames[agent], shellPath: agent, shellArgs: ['run', prompt] }
   }
 }

--- a/src/extension/aiTerminal.ts
+++ b/src/extension/aiTerminal.ts
@@ -55,11 +55,18 @@ export function buildAITerminalLaunch(
       return { name: agentNames[agent], shellPath: agent, shellArgs }
     }
     case 'codex': {
-      const approvalMap: Record<AIPermissionMode, string> = {
-        default: 'ask',
-        plan: 'ask',
-        acceptEdits: 'auto',
-        bypassPermissions: 'full-auto'
+      if (permissionMode === 'bypassPermissions') {
+        return {
+          name: agentNames[agent],
+          shellPath: agent,
+          shellArgs: ['--dangerously-bypass-approvals-and-sandbox', prompt]
+        }
+      }
+
+      const approvalMap: Record<Exclude<AIPermissionMode, 'bypassPermissions'>, string> = {
+        default: 'on-request',
+        plan: 'on-request',
+        acceptEdits: 'never'
       }
       return {
         name: agentNames[agent],

--- a/tests/extension/aiTerminal.test.ts
+++ b/tests/extension/aiTerminal.test.ts
@@ -74,11 +74,11 @@ describe('aiTerminal', () => {
       .toEqual(['--dangerously-bypass-approvals-and-sandbox', 'prompt'])
   })
 
-  it('runs OpenCode through the run subcommand', () => {
+  it('starts OpenCode interactively with the prompt', () => {
     expect(buildAITerminalLaunch('opencode', 'default', 'prompt')).toEqual({
       name: 'OpenCode',
       shellPath: 'opencode',
-      shellArgs: ['run', 'prompt']
+      shellArgs: ['--prompt', 'prompt']
     })
   })
 

--- a/tests/extension/aiTerminal.test.ts
+++ b/tests/extension/aiTerminal.test.ts
@@ -74,6 +74,14 @@ describe('aiTerminal', () => {
       .toEqual(['--dangerously-bypass-approvals-and-sandbox', 'prompt'])
   })
 
+  it('runs OpenCode through the run subcommand', () => {
+    expect(buildAITerminalLaunch('opencode', 'default', 'prompt')).toEqual({
+      name: 'OpenCode',
+      shellPath: 'opencode',
+      shellArgs: ['run', 'prompt']
+    })
+  })
+
   it('normalizes unknown webview/config values to safe defaults', () => {
     expect(normalizeAIAgent('copilot')).toBe('copilot')
     expect(normalizeAIAgent('powershell')).toBe('claude')

--- a/tests/extension/aiTerminal.test.ts
+++ b/tests/extension/aiTerminal.test.ts
@@ -65,13 +65,13 @@ describe('aiTerminal', () => {
 
   it('maps Codex permission modes to approval arguments', () => {
     expect(buildAITerminalLaunch('codex', 'default', 'prompt').shellArgs)
-      .toEqual(['--ask-for-approval', 'ask', 'prompt'])
+      .toEqual(['--ask-for-approval', 'on-request', 'prompt'])
     expect(buildAITerminalLaunch('codex', 'plan', 'prompt').shellArgs)
-      .toEqual(['--ask-for-approval', 'ask', 'prompt'])
+      .toEqual(['--ask-for-approval', 'on-request', 'prompt'])
     expect(buildAITerminalLaunch('codex', 'acceptEdits', 'prompt').shellArgs)
-      .toEqual(['--ask-for-approval', 'auto', 'prompt'])
+      .toEqual(['--ask-for-approval', 'never', 'prompt'])
     expect(buildAITerminalLaunch('codex', 'bypassPermissions', 'prompt').shellArgs)
-      .toEqual(['--ask-for-approval', 'full-auto', 'prompt'])
+      .toEqual(['--dangerously-bypass-approvals-and-sandbox', 'prompt'])
   })
 
   it('normalizes unknown webview/config values to safe defaults', () => {

--- a/tests/extension/aiTerminal.test.ts
+++ b/tests/extension/aiTerminal.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildAITerminalLaunch,
+  buildFeaturePrompt,
+  normalizeAIAgent,
+  normalizeAIPermissionMode
+} from '../../src/extension/aiTerminal'
+
+describe('aiTerminal', () => {
+  it('builds a feature prompt from feature context', () => {
+    const prompt = buildFeaturePrompt({
+      title: 'Add swimlanes',
+      priority: 'high',
+      labels: ['ui', 'planning'],
+      content: '# Add swimlanes\n\nGroup cards by epic.',
+      filePath: '/workspace/.devtool/features/add-swimlanes.md'
+    })
+
+    expect(prompt).toBe(
+      'Implement this feature: "Add swimlanes" (high priority) [ui, planning]. # Add swimlanes Group cards by epic. See full details in: /workspace/.devtool/features/add-swimlanes.md'
+    )
+  })
+
+  it('truncates long descriptions using the existing 200 character limit', () => {
+    const prompt = buildFeaturePrompt({
+      title: 'Long feature',
+      priority: 'medium',
+      labels: [],
+      content: 'x'.repeat(201),
+      filePath: '/workspace/feature.md'
+    })
+
+    expect(prompt).toContain(`${'x'.repeat(200)}... See full details in: /workspace/feature.md`)
+  })
+
+  it('passes prompts with shell metacharacters as one terminal argument', () => {
+    const prompt = buildFeaturePrompt({
+      title: "bad'; Write-Host pwned; '",
+      priority: 'critical',
+      labels: ['security'],
+      content: "Do not split this: $(whoami) & calc.exe | echo 'owned'",
+      filePath: 'C:\\workspace\\feature.md'
+    })
+
+    const launch = buildAITerminalLaunch('claude', 'default', prompt)
+
+    expect(launch).toEqual({
+      name: 'Claude Code',
+      shellPath: 'claude',
+      shellArgs: [prompt]
+    })
+    expect(launch.shellArgs[0]).toContain("bad'; Write-Host pwned; '")
+    expect(launch.shellArgs[0]).not.toContain("'\\''")
+  })
+
+  it('adds Claude permission mode arguments before the prompt', () => {
+    const launch = buildAITerminalLaunch('claude', 'acceptEdits', 'prompt')
+
+    expect(launch).toEqual({
+      name: 'Claude Code',
+      shellPath: 'claude',
+      shellArgs: ['--permission-mode', 'acceptEdits', 'prompt']
+    })
+  })
+
+  it('maps Codex permission modes to approval arguments', () => {
+    expect(buildAITerminalLaunch('codex', 'default', 'prompt').shellArgs)
+      .toEqual(['--ask-for-approval', 'ask', 'prompt'])
+    expect(buildAITerminalLaunch('codex', 'plan', 'prompt').shellArgs)
+      .toEqual(['--ask-for-approval', 'ask', 'prompt'])
+    expect(buildAITerminalLaunch('codex', 'acceptEdits', 'prompt').shellArgs)
+      .toEqual(['--ask-for-approval', 'auto', 'prompt'])
+    expect(buildAITerminalLaunch('codex', 'bypassPermissions', 'prompt').shellArgs)
+      .toEqual(['--ask-for-approval', 'full-auto', 'prompt'])
+  })
+
+  it('normalizes unknown webview/config values to safe defaults', () => {
+    expect(normalizeAIAgent('copilot')).toBe('copilot')
+    expect(normalizeAIAgent('powershell')).toBe('claude')
+    expect(normalizeAIAgent(undefined)).toBe('claude')
+
+    expect(normalizeAIPermissionMode('plan')).toBe('plan')
+    expect(normalizeAIPermissionMode('unsafe-mode')).toBe('default')
+    expect(normalizeAIPermissionMode(undefined)).toBe('default')
+  })
+})

--- a/tests/extension/aiTerminal.test.ts
+++ b/tests/extension/aiTerminal.test.ts
@@ -82,6 +82,14 @@ describe('aiTerminal', () => {
     })
   })
 
+  it('starts Copilot interactively with the prompt', () => {
+    expect(buildAITerminalLaunch('copilot', 'default', 'prompt')).toEqual({
+      name: 'GitHub Copilot',
+      shellPath: 'copilot',
+      shellArgs: ['--interactive', 'prompt']
+    })
+  })
+
   it('normalizes unknown webview/config values to safe defaults', () => {
     expect(normalizeAIAgent('copilot')).toBe('copilot')
     expect(normalizeAIAgent('powershell')).toBe('claude')


### PR DESCRIPTION
Fixes #58.

Thanks @teacher-svb for reporting the Windows PowerShell/cmd injection risk in the Build with AI launch path, and thanks @drorgl for reporting the OpenCode argument bug in #56.

Feature prompts are now passed as terminal shell arguments instead of shell-quoted text sent through `sendText`, and each built-in agent now uses its current CLI launch shape: Claude permission modes, Codex approval policies, Copilot `--interactive`, and OpenCode `--prompt`.

This addresses the OpenCode bug portion of #56 without implementing the custom-agent enhancement from that issue.

Validation:
- `pnpm run typecheck`
- `pnpm test`
- `pnpm run lint`
- `pnpm run build`