### PR TITLE
feat: CRUD for task comments

### DIFF
--- a/l10n/bundle.l10n.en.json
+++ b/l10n/bundle.l10n.en.json
@@ -184,5 +184,17 @@
   "sidebar.newFeature": "New Feature",
   "sidebar.overview": "Overview",
   "sidebar.total": "{count} total",
-  "sidebar.inProgress": "In Progress"
+  "sidebar.inProgress": "In Progress",
+
+  "comments.heading": "Comments",
+  "comments.dateTime": "Date Time",
+  "comments.content": "Content",
+  "comments.author": "Author",
+  "comments.placeholder": "Add a comment...",
+  "comments.authorPlaceholder": "Author",
+  "comments.add": "Add comment",
+  "comments.edit": "Edit comment",
+  "comments.save": "Save comment",
+  "comments.cancel": "Cancel",
+  "comments.delete": "Delete comment"
 }

--- a/l10n/bundle.l10n.es.json
+++ b/l10n/bundle.l10n.es.json
@@ -184,5 +184,17 @@
   "sidebar.newFeature": "Nueva función",
   "sidebar.overview": "Resumen",
   "sidebar.total": "{count} en total",
-  "sidebar.inProgress": "En progreso"
+  "sidebar.inProgress": "En progreso",
+
+  "comments.heading": "Comentarios",
+  "comments.dateTime": "Fecha y hora",
+  "comments.content": "Contenido",
+  "comments.author": "Autor",
+  "comments.placeholder": "Añadir un comentario...",
+  "comments.authorPlaceholder": "Autor",
+  "comments.add": "Añadir comentario",
+  "comments.edit": "Editar comentario",
+  "comments.save": "Guardar comentario",
+  "comments.cancel": "Cancelar",
+  "comments.delete": "Eliminar comentario"
 }

--- a/l10n/bundle.l10n.pt.json
+++ b/l10n/bundle.l10n.pt.json
@@ -184,5 +184,17 @@
   "sidebar.newFeature": "Nova funcionalidade",
   "sidebar.overview": "Resumo",
   "sidebar.total": "{count} no total",
-  "sidebar.inProgress": "Em progresso"
+  "sidebar.inProgress": "Em progresso",
+
+  "comments.heading": "Comentários",
+  "comments.dateTime": "Data e hora",
+  "comments.content": "Conteúdo",
+  "comments.author": "Autor",
+  "comments.placeholder": "Adicionar um comentário...",
+  "comments.authorPlaceholder": "Autor",
+  "comments.add": "Adicionar comentário",
+  "comments.edit": "Editar comentário",
+  "comments.save": "Guardar comentário",
+  "comments.cancel": "Cancelar",
+  "comments.delete": "Eliminar comentário"
 }

--- a/src/extension/KanbanPanel.ts
+++ b/src/extension/KanbanPanel.ts
@@ -6,6 +6,7 @@ import { getTitleFromContent, generateFeatureFilename } from '../shared/types'
 import type { Feature, FeatureStatus, Priority, KanbanColumn, FeatureFrontmatter, CardDisplaySettings, FilenamePattern, AIAgent, AIPermissionMode, BoardViewMode } from '../shared/types'
 import { ensureStatusSubfolders, moveFeatureFile, getFeatureFilePath, getStatusFromPath, fileExists } from './featureFileUtils'
 import { parseFeatureFile, serializeFeature } from '../shared/featureFrontmatter'
+import { ensureCommentsSection } from '../shared/comments'
 import { featureMatchesEpicLane } from '../shared/epicLane'
 import { t, getBundle, getEffectiveLocale, reloadBundle, getAllDefaultColumnNames, getDefaultColumnNamesForLocale } from './l10n'
 
@@ -585,7 +586,7 @@ export class KanbanPanel {
       completedAt: data.status === 'done' ? now : null,
       labels: data.labels,
       order: newOrder,
-      content: data.content,
+      content: ensureCommentsSection(data.content),
       filePath
     }
 
@@ -868,7 +869,7 @@ export class KanbanPanel {
     const oldStatus = feature.status
 
     // Update feature in memory
-    feature.content = content
+    feature.content = ensureCommentsSection(content)
     feature.status = frontmatter.status
     feature.priority = frontmatter.priority
     feature.assignee = frontmatter.assignee

--- a/src/shared/comments.ts
+++ b/src/shared/comments.ts
@@ -1,0 +1,106 @@
+// Task comments stored as a markdown table under a `## Comments` heading
+// at the end of a feature file.
+
+export interface TaskComment {
+  dateTime: string
+  content: string
+  author: string
+}
+
+export const COMMENTS_HEADING = '## Comments'
+
+const HEADER_ROW = '| Date Time | Content | Author |'
+const SEPARATOR_ROW = '|-----------|---------|--------|'
+
+const HEADING_RE = /^##[ \t]+Comments[ \t]*\r?$/m
+
+function sanitizeCell(value: string): string {
+  return value.replace(/\|/g, '\\|').replace(/\r?\n/g, ' ').trim()
+}
+
+function unsanitizeCell(value: string): string {
+  return value.replace(/\\\|/g, '|').trim()
+}
+
+export function buildCommentsSection(comments: TaskComment[]): string {
+  const rows = comments.map(
+    (c) => `| ${sanitizeCell(c.dateTime)} | ${sanitizeCell(c.content)} | ${sanitizeCell(c.author)} |`
+  )
+  return [COMMENTS_HEADING, '', HEADER_ROW, SEPARATOR_ROW, ...rows].join('\n')
+}
+
+export function hasCommentsSection(content: string): boolean {
+  return HEADING_RE.test(content)
+}
+
+export function ensureCommentsSection(content: string): string {
+  if (hasCommentsSection(content)) return content
+  const body = content.trimEnd()
+  return `${body}\n\n${buildCommentsSection([])}\n`
+}
+
+function isSeparatorRow(cells: string[]): boolean {
+  return cells.length > 0 && cells.every((c) => /^:?-{3,}:?$/.test(c.trim()))
+}
+
+function splitRow(line: string): string[] {
+  let t = line.trim()
+  if (t.startsWith('|')) t = t.slice(1)
+  if (t.endsWith('|')) t = t.slice(0, -1)
+  // Split on unescaped pipes
+  return t.split(/(?<!\\)\|/).map((c) => unsanitizeCell(c))
+}
+
+export interface SplitCommentsResult {
+  body: string
+  comments: TaskComment[]
+  hasSection: boolean
+}
+
+// Splits feature content into the editable body and the parsed comments.
+// Any non-table content after the heading is preserved by appending it to the body.
+export function splitComments(content: string): SplitCommentsResult {
+  const match = content.match(HEADING_RE)
+  if (!match || match.index === undefined) {
+    return { body: content, comments: [], hasSection: false }
+  }
+
+  const before = content.slice(0, match.index)
+  const after = content.slice(match.index + match[0].length)
+
+  const comments: TaskComment[] = []
+  const rest: string[] = []
+  let inTable = false
+  let tableDone = false
+
+  for (const line of after.split('\n')) {
+    const trimmed = line.trim()
+    if (!tableDone && trimmed.startsWith('|')) {
+      const cells = splitRow(line)
+      if (isSeparatorRow(cells)) {
+        inTable = true
+        continue
+      }
+      if (!inTable && cells[0] === 'Date Time') continue // header row
+      if (inTable && cells.length >= 3) {
+        comments.push({ dateTime: cells[0], content: cells[1], author: cells.slice(2).join(' | ') })
+        continue
+      }
+    }
+    if (!tableDone && trimmed === '') continue // blank lines around the table
+    if (inTable) tableDone = true
+    rest.push(line)
+  }
+
+  const trailing = rest.join('\n').trim()
+  let body = before.trimEnd()
+  if (trailing) body = body ? `${body}\n\n${trailing}` : trailing
+
+  return { body, comments, hasSection: true }
+}
+
+// Recombines an edited body with comments into full feature content.
+export function withComments(body: string, comments: TaskComment[]): string {
+  const trimmed = body.trimEnd()
+  return `${trimmed}\n\n${buildCommentsSection(comments)}\n`
+}

--- a/src/webview/components/CommentsSection.tsx
+++ b/src/webview/components/CommentsSection.tsx
@@ -1,0 +1,186 @@
+import { useState } from 'react'
+import { Plus, Trash2, Pencil, Check, X } from 'lucide-react'
+import type { TaskComment } from '../../shared/comments'
+import { t } from '../lib/i18n'
+
+interface CommentsSectionProps {
+  comments: TaskComment[]
+  defaultAuthor: string
+  onChange: (comments: TaskComment[]) => void
+}
+
+export function CommentsSection({ comments, defaultAuthor, onChange }: CommentsSectionProps) {
+  const [newContent, setNewContent] = useState('')
+  const [newAuthor, setNewAuthor] = useState('')
+  const [editingIndex, setEditingIndex] = useState<number | null>(null)
+  const [editContent, setEditContent] = useState('')
+
+  const addComment = () => {
+    const content = newContent.trim()
+    if (!content) return
+    const author = (newAuthor.trim() || defaultAuthor || '').trim()
+    onChange([...comments, { dateTime: new Date().toISOString(), content, author }])
+    setNewContent('')
+  }
+
+  const removeComment = (index: number) => {
+    onChange(comments.filter((_, i) => i !== index))
+  }
+
+  const startEdit = (index: number) => {
+    setEditingIndex(index)
+    setEditContent(comments[index].content)
+  }
+
+  const commitEdit = () => {
+    if (editingIndex === null) return
+    const content = editContent.trim()
+    if (content) {
+      onChange(comments.map((c, i) => (i === editingIndex ? { ...c, content } : c)))
+    }
+    setEditingIndex(null)
+  }
+
+  return (
+    <div
+      className="px-4 py-3"
+      style={{ borderTop: '1px solid var(--vscode-panel-border)' }}
+    >
+      <div
+        className="text-[11px] font-semibold uppercase tracking-wide mb-2"
+        style={{ color: 'var(--vscode-descriptionForeground)' }}
+      >
+        {t('comments.heading')}
+      </div>
+
+      {comments.length > 0 && (
+        <table className="w-full text-xs mb-2" style={{ color: 'var(--vscode-foreground)' }}>
+          <thead>
+            <tr
+              className="text-left text-[10px]"
+              style={{ color: 'var(--vscode-descriptionForeground)' }}
+            >
+              <th className="pr-2 py-1 font-medium whitespace-nowrap">{t('comments.dateTime')}</th>
+              <th className="pr-2 py-1 font-medium w-full">{t('comments.content')}</th>
+              <th className="pr-2 py-1 font-medium whitespace-nowrap">{t('comments.author')}</th>
+              <th className="py-1 font-medium w-8" />
+            </tr>
+          </thead>
+          <tbody>
+            {comments.map((comment, i) => (
+              <tr key={i} style={{ borderTop: '1px solid var(--vscode-panel-border)' }}>
+                <td className="pr-2 py-1.5 whitespace-nowrap align-top">
+                  {new Date(comment.dateTime).toLocaleString()}
+                </td>
+                <td className="pr-2 py-1.5 align-top">
+                  {editingIndex === i ? (
+                    <input
+                      type="text"
+                      value={editContent}
+                      autoFocus
+                      onChange={(e) => setEditContent(e.target.value)}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter') commitEdit()
+                        if (e.key === 'Escape') setEditingIndex(null)
+                      }}
+                      className="w-full bg-transparent border-none outline-none text-xs"
+                      style={{ color: 'var(--vscode-foreground)' }}
+                    />
+                  ) : (
+                    comment.content
+                  )}
+                </td>
+                <td className="pr-2 py-1.5 whitespace-nowrap align-top">{comment.author}</td>
+                <td className="py-1.5 align-top">
+                  <div className="flex items-center gap-1">
+                    {editingIndex === i ? (
+                      <>
+                        <button
+                          onClick={commitEdit}
+                          className="p-0.5 rounded transition-colors vscode-hover-bg"
+                          style={{ color: 'var(--vscode-descriptionForeground)' }}
+                          title={t('comments.save')}
+                        >
+                          <Check size={12} />
+                        </button>
+                        <button
+                          onClick={() => setEditingIndex(null)}
+                          className="p-0.5 rounded transition-colors vscode-hover-bg"
+                          style={{ color: 'var(--vscode-descriptionForeground)' }}
+                          title={t('comments.cancel')}
+                        >
+                          <X size={12} />
+                        </button>
+                      </>
+                    ) : (
+                      <>
+                        <button
+                          onClick={() => startEdit(i)}
+                          className="p-0.5 rounded transition-colors vscode-hover-bg"
+                          style={{ color: 'var(--vscode-descriptionForeground)' }}
+                          title={t('comments.edit')}
+                        >
+                          <Pencil size={12} />
+                        </button>
+                        <button
+                          onClick={() => removeComment(i)}
+                          className="p-0.5 rounded transition-colors vscode-hover-bg hover:text-red-500"
+                          style={{ color: 'var(--vscode-descriptionForeground)' }}
+                          title={t('comments.delete')}
+                        >
+                          <Trash2 size={12} />
+                        </button>
+                      </>
+                    )}
+                  </div>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+
+      <div className="flex items-center gap-1.5">
+        <input
+          type="text"
+          value={newContent}
+          onChange={(e) => setNewContent(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') addComment()
+          }}
+          placeholder={t('comments.placeholder')}
+          className="flex-1 min-w-0 px-2 py-1 text-xs rounded"
+          style={{
+            background: 'var(--vscode-input-background)',
+            color: 'var(--vscode-input-foreground)',
+            border: '1px solid var(--vscode-input-border, transparent)'
+          }}
+        />
+        <input
+          type="text"
+          value={newAuthor}
+          onChange={(e) => setNewAuthor(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') addComment()
+          }}
+          placeholder={defaultAuthor || t('comments.authorPlaceholder')}
+          className="w-24 px-2 py-1 text-xs rounded"
+          style={{
+            background: 'var(--vscode-input-background)',
+            color: 'var(--vscode-input-foreground)',
+            border: '1px solid var(--vscode-input-border, transparent)'
+          }}
+        />
+        <button
+          onClick={addComment}
+          disabled={!newContent.trim()}
+          className="p-1.5 rounded transition-colors vscode-hover-bg disabled:opacity-40"
+          style={{ color: 'var(--vscode-foreground)' }}
+          title={t('comments.add')}
+        >
+          <Plus size={14} />
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/src/webview/components/FeatureEditor.tsx
+++ b/src/webview/components/FeatureEditor.tsx
@@ -25,11 +25,13 @@ import type {
   AIAgent,
   AIPermissionMode
 } from '../../shared/types'
+import { splitComments, withComments, type TaskComment } from '../../shared/comments'
 import { cn } from '../lib/utils'
 import { t } from '../lib/i18n'
 import { useStore } from '../store'
 import { AssigneeInput } from './AssigneeInput'
 import { EpicInput } from './EpicInput'
+import { CommentsSection } from './CommentsSection'
 
 interface MarkdownStorage {
   markdown: { getMarkdown: () => string }
@@ -537,12 +539,20 @@ export function FeatureEditor({
   const { cardSettings } = useStore()
   const [currentFrontmatter, setCurrentFrontmatter] = useState(frontmatter)
   const [confirmingDelete, setConfirmingDelete] = useState(false)
+  const [comments, setComments] = useState<TaskComment[]>(() => splitComments(content).comments)
   const priorityLabels = getPriorityLabels()
   const statusLabels = getStatusLabels()
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const isInitialLoad = useRef(true)
   const currentFrontmatterRef = useRef(currentFrontmatter)
   currentFrontmatterRef.current = currentFrontmatter
+  const commentsRef = useRef(comments)
+  commentsRef.current = comments
+
+  const getFullMarkdown = useCallback(
+    (ed: { storage: unknown }) => withComments(getMarkdown(ed), commentsRef.current),
+    []
+  )
 
   const editor = useEditor({
     extensions: [
@@ -560,17 +570,15 @@ export function FeatureEditor({
       if (isInitialLoad.current) return
       if (debounceRef.current) clearTimeout(debounceRef.current)
       debounceRef.current = setTimeout(() => {
-        const markdown = getMarkdown(ed)
-        onSave(markdown, currentFrontmatterRef.current)
+        onSave(getFullMarkdown(ed), currentFrontmatterRef.current)
       }, 800)
     }
   })
 
   const save = useCallback(() => {
     if (!editor) return
-    const markdown = getMarkdown(editor)
-    onSave(markdown, currentFrontmatter)
-  }, [editor, currentFrontmatter, onSave])
+    onSave(getFullMarkdown(editor), currentFrontmatter)
+  }, [editor, currentFrontmatter, onSave, getFullMarkdown])
 
   // Clean up debounce on unmount
   useEffect(() => {
@@ -582,8 +590,10 @@ export function FeatureEditor({
   // Set content when a new feature is opened (keyed by featureId, not content)
   useEffect(() => {
     if (editor && content) {
+      const { body, comments: parsed } = splitComments(content)
+      setComments(parsed)
       isInitialLoad.current = true
-      editor.commands.setContent(content)
+      editor.commands.setContent(body)
       // Allow a tick for the onUpdate from setContent to fire, then re-enable
       requestAnimationFrame(() => {
         isInitialLoad.current = false
@@ -605,11 +615,22 @@ export function FeatureEditor({
         if (debounceRef.current) clearTimeout(debounceRef.current)
         debounceRef.current = setTimeout(() => {
           if (!editor) return
-          const markdown = getMarkdown(editor)
-          onSave(markdown, next)
+          onSave(getFullMarkdown(editor), next)
         }, 800)
         return next
       })
+    },
+    [editor, onSave, getFullMarkdown]
+  )
+
+  const handleCommentsChange = useCallback(
+    (next: TaskComment[]) => {
+      setComments(next)
+      if (debounceRef.current) clearTimeout(debounceRef.current)
+      debounceRef.current = setTimeout(() => {
+        if (!editor) return
+        onSave(withComments(getMarkdown(editor), next), currentFrontmatterRef.current)
+      }, 800)
     },
     [editor, onSave]
   )
@@ -794,7 +815,12 @@ export function FeatureEditor({
 
       {/* Editor */}
       <div className="flex-1 overflow-auto">
-        <EditorContent editor={editor} className="h-full" />
+        <EditorContent editor={editor} />
+        <CommentsSection
+          comments={comments}
+          defaultAuthor={currentFrontmatter.assignee || ''}
+          onChange={handleCommentsChange}
+        />
       </div>
     </div>
   )

--- a/tests/shared/comments.test.ts
+++ b/tests/shared/comments.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest'
+import {
+  ensureCommentsSection,
+  splitComments,
+  withComments,
+  buildCommentsSection,
+  hasCommentsSection,
+  type TaskComment
+} from '../../src/shared/comments'
+
+const SAMPLE_COMMENTS: TaskComment[] = [
+  { dateTime: '2026-08-24T10:00:00.000Z', content: 'First comment', author: 'bob' },
+  { dateTime: '2026-08-24T11:00:00.000Z', content: 'Second comment', author: 'alice' }
+]
+
+describe('ensureCommentsSection', () => {
+  it('appends an empty comments table to content without one', () => {
+    const result = ensureCommentsSection('# My Task\n\nSome description')
+    expect(result).toBe(
+      '# My Task\n\nSome description\n\n## Comments\n\n| Date Time | Content | Author |\n|-----------|---------|--------|\n'
+    )
+  })
+
+  it('is idempotent when the section already exists', () => {
+    const once = ensureCommentsSection('# My Task')
+    expect(ensureCommentsSection(once)).toBe(once)
+  })
+})
+
+describe('splitComments', () => {
+  it('returns the full content as body when no section exists', () => {
+    const { body, comments, hasSection } = splitComments('# Task\n\nbody text')
+    expect(body).toBe('# Task\n\nbody text')
+    expect(comments).toEqual([])
+    expect(hasSection).toBe(false)
+  })
+
+  it('parses comment rows and strips the section from the body', () => {
+    const content = `# Task\n\nbody text\n\n${buildCommentsSection(SAMPLE_COMMENTS)}\n`
+    const { body, comments, hasSection } = splitComments(content)
+    expect(body).toBe('# Task\n\nbody text')
+    expect(comments).toEqual(SAMPLE_COMMENTS)
+    expect(hasSection).toBe(true)
+  })
+
+  it('preserves non-table content written after the section', () => {
+    const content = `# Task\n\nbody\n\n${buildCommentsSection(SAMPLE_COMMENTS)}\n\nextra notes\n`
+    const { body, comments } = splitComments(content)
+    expect(comments).toEqual(SAMPLE_COMMENTS)
+    expect(body).toContain('extra notes')
+    expect(body).toContain('body')
+  })
+
+  it('handles an empty comments table', () => {
+    const { body, comments, hasSection } = splitComments(ensureCommentsSection('# Task'))
+    expect(body).toBe('# Task')
+    expect(comments).toEqual([])
+    expect(hasSection).toBe(true)
+  })
+})
+
+describe('withComments', () => {
+  it('round-trips through splitComments', () => {
+    const full = withComments('# Task\n\nbody', SAMPLE_COMMENTS)
+    const { body, comments } = splitComments(full)
+    expect(body).toBe('# Task\n\nbody')
+    expect(comments).toEqual(SAMPLE_COMMENTS)
+  })
+
+  it('escapes pipe characters in cells', () => {
+    const full = withComments('body', [
+      { dateTime: '2026-08-24T10:00:00.000Z', content: 'a | b', author: 'bob' }
+    ])
+    const { comments } = splitComments(full)
+    expect(comments[0].content).toBe('a | b')
+  })
+})
+
+describe('hasCommentsSection', () => {
+  it('does not match headings of other levels or text mentions', () => {
+    expect(hasCommentsSection('### Comments')).toBe(false)
+    expect(hasCommentsSection('## Comments')).toBe(true)
+  })
+})


### PR DESCRIPTION
## What

Adds task comments stored as a markdown table at the end of each feature file:

```markdown
## Comments

| Date Time | Content | Author |
|-----------|---------|--------|
| 2026-08-24T10:00:00.000Z | Looks good | bob |
```

- **Auto-section**: new feature files get an empty `## Comments` table appended on creation (`ensureCommentsSection` in `src/shared/comments.ts`); saves also re-ensure the section so older cards gain it on next edit.
- **Custom UI**: the feature editor strips the comments section out of the rich-text body and renders a dedicated `CommentsSection` component below it with **add** (auto timestamp, author defaults to assignee), **inline edit**, and **delete**.
- **Round-trip safe**: pipe characters in cells are escaped; any non-table markdown a user writes below the section is preserved (moved back into the body on save).
- en/es/pt l10n strings included.

## Tests

- New `tests/shared/comments.test.ts` (9 tests): ensure/split/withComments round-trips, escaping, trailing-content preservation.
- `typecheck`, `lint`, `check-l10n`, `build` all pass. Two pre-existing webview test failures (`FeatureCard`, `KanbanBoard`) also fail on `main` — unrelated.